### PR TITLE
Remove outdated EF Core 2.1 workaround from RoleService

### DIFF
--- a/TASVideos.Core/Services/RoleService.cs
+++ b/TASVideos.Core/Services/RoleService.cs
@@ -29,14 +29,13 @@ internal class RoleService(ApplicationDbContext db) : IRoleService
 			{
 				r.Id,
 				r.Name,
-				Diabled = !r.RolePermission.All(rp => assignablePermissions.Contains(rp.PermissionId))
-					&& assignedRoleList.Any() // EF Core 2.1 issue, needs this or a user with no assigned roles blows up
+				Disabled = !r.RolePermission.All(rp => assignablePermissions.Contains(rp.PermissionId))
 					&& assignedRoleList.Contains(r.Id)
 			})
 			.OrderBy(s => s.Name)
 			.ToListAsync();
 
-		return roles.Select(r => new AssignableRole(r.Id, r.Name, r.Diabled));
+		return roles.Select(r => new AssignableRole(r.Id, r.Name, r.Disabled));
 	}
 
 	public async Task<bool> IsInUse(int roleId) => await db.Users.AnyAsync(u => u.UserRoles.Any(ur => ur.RoleId == roleId));

--- a/tests/TASVideos.Core.Tests/Services/RoleServiceTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/RoleServiceTests.cs
@@ -42,4 +42,20 @@ public class RoleServiceTests : TestDbBase
 		var actual = await _roleService.IsInUse(existingRoleId);
 		Assert.IsTrue(actual);
 	}
+
+	[TestMethod]
+	public async Task GetAllRolesUserCanAssign_UserWithNoAssignedRoles_ReturnsRoles()
+	{
+		// Test for the edge case that the EF Core 2.1 workaround was addressing
+		var user = _db.AddUser(1);
+		_db.Roles.Add(new Role { Id = 1, Name = "TestRole1" });
+		_db.Roles.Add(new Role { Id = 2, Name = "TestRole2" });
+		await _db.SaveChangesAsync();
+
+		// User has no assigned roles - empty list
+		var result = await _roleService.GetAllRolesUserCanAssign(user.Entity.Id, []);
+
+		// Should not throw an exception and should return roles
+		Assert.IsNotNull(result);
+	}
 }


### PR DESCRIPTION
- Remove unnecessary `&& assignedRoleList.Any()` check that was added as a workaround for EF Core 2.1
- Fix typo: Diabled → Disabled
- Add test case for edge case (user with no assigned roles)
- Modern EF Core 8 handles empty list Contains() checks properly without workarounds

This was the only EF Core 2.1 reference in the codebase.