### PR TITLE
Add Architecture Decision Records (ADRs) documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Contributions are encouraged but should follow site coding standards: https://ta
 # Try it out!
 Wiki page for setting up local development: https://github.com/TASVideos/tasvideos/wiki/Local-Development-Setup
 
+# Documentation
+
+- **[Architecture Decision Records (ADRs)](./docs/architecture/README.md)** - Key architectural decisions and their rationale
+- **[Frontend Design Specification](./docs/DESIGN-SPEC.md)** - Frontend design guidelines and standards
+
 ---
 
 **Why did the TAS speedrunner break up with their partner?**

--- a/docs/architecture/ADR-0001-dotnet-aspnetcore.md
+++ b/docs/architecture/ADR-0001-dotnet-aspnetcore.md
@@ -1,0 +1,156 @@
+# ADR-0001: Use .NET 8 and ASP.NET Core with Razor Pages
+
+## Status
+
+Accepted
+
+## Date
+
+2024-11-18 (Documented retrospectively)
+
+## Decision Makers
+
+* TASVideos Development Team
+
+## Context
+
+TASVideos needed a modern, performant web framework to support:
+- Server-side rendered pages for SEO and accessibility
+- RESTful API for mobile apps and third-party integrations
+- Long-term support and active development from the platform vendor
+- Strong typing and compile-time safety
+- Cross-platform deployment capabilities
+- Integration with existing .NET ecosystem libraries
+
+The application has complex domain logic including:
+- Forum and wiki engines
+- Movie file parsing from 23+ different formats
+- Publication workflow with multiple approval stages
+- User authentication and fine-grained permissions
+- Full-text search capabilities
+
+## Decision
+
+Use **.NET 8.0** with **ASP.NET Core** and **Razor Pages** architecture.
+
+### Key Technology Choices
+
+1. **.NET 8.0** (LTS release)
+   - Target framework: `net8.0`
+   - C# 12.0 language features
+   - Long-term support until November 2026
+
+2. **ASP.NET Core Razor Pages** for web UI
+   - Page-focused development model
+   - Better suited for content-heavy pages than MVC
+   - Built-in anti-forgery protection
+
+3. **Minimal APIs** for RESTful endpoints
+   - Lightweight alternative to controllers
+   - Better performance for simple API routes
+   - Cleaner route definition with route groups
+
+4. **Modular architecture** with extension methods
+   - Each subsystem (Data, Core, API, Parsers) is a separate library
+   - Self-contained dependency injection via `ServiceCollectionExtensions.cs`
+   - Clean separation of concerns
+
+### Implementation Details
+
+**Project Structure:**
+- `TASVideos.Data` - Entity Framework Core data access
+- `TASVideos.Core` - Business logic and services
+- `TASVideos.Api` - REST API endpoints
+- `TASVideos.Parsers` - Movie file parsers
+- `TASVideos.ForumEngine` - Forum markup processing
+- `TASVideos.WikiEngine` - Wiki markup processing
+- `tasvideos` - Main web application
+
+**Configuration:** Directory.Build.props
+```xml
+<TargetFramework>net8.0</TargetFramework>
+<LangVersion>12.0</LangVersion>
+<Nullable>enable</Nullable>
+<ImplicitUsings>enable</ImplicitUsings>
+```
+
+**Centralized Package Management:** Directory.Packages.props
+- All package versions defined in single file
+- Prevents version conflicts across projects
+- Easier to maintain and update dependencies
+
+## Alternatives Considered
+
+### Node.js with Express/Next.js
+**Pros:**
+- Large ecosystem
+- JavaScript/TypeScript familiarity
+- Good for real-time features
+
+**Cons:**
+- Weaker typing (even with TypeScript)
+- Less suitable for CPU-intensive parsing tasks
+- Higher memory usage for long-running processes
+
+**Why not chosen:** Movie file parsing and complex domain logic benefit from .NET's performance and strong typing.
+
+### Python with Django/Flask
+**Pros:**
+- Rapid development
+- Strong data science libraries
+- Good for prototyping
+
+**Cons:**
+- Performance limitations for high-traffic scenarios
+- GIL (Global Interpreter Lock) issues
+- Deployment complexity
+
+**Why not chosen:** Performance requirements and need for compile-time safety.
+
+### Java with Spring Boot
+**Pros:**
+- Mature ecosystem
+- Enterprise-grade features
+- Strong typing
+
+**Cons:**
+- More verbose than C#
+- Slower startup times
+- Heavier resource usage
+
+**Why not chosen:** .NET offers similar benefits with better developer experience and performance.
+
+## Consequences
+
+### Positive
+
+* **Performance:** Excellent runtime performance and startup times
+* **Long-term support:** .NET 8 LTS supported until November 2026
+* **Type safety:** Nullable reference types catch potential bugs at compile-time
+* **Developer productivity:** Modern C# features reduce boilerplate code
+* **Tooling:** Excellent IDE support (Visual Studio, Rider, VS Code)
+* **Cross-platform:** Runs on Linux, Windows, macOS
+* **Modular architecture:** Easy to test and maintain individual components
+* **Central package management:** Simplifies dependency updates
+
+### Negative
+
+* **Learning curve:** Developers need .NET/C# knowledge
+* **Windows legacy:** Some tools and documentation assume Windows development
+* **Breaking changes:** Future .NET versions may require migration effort
+* **Package ecosystem:** Smaller than JavaScript ecosystem for some niches
+
+### Neutral
+
+* **.NET release cadence:** New major version every November
+* **Microsoft dependency:** Framework direction controlled by Microsoft
+* **Memory footprint:** Higher than interpreted languages, lower than JVM
+
+## Links
+
+* Code: [Directory.Build.props](../../Directory.Build.props)
+* Code: [Directory.Packages.props](../../Directory.Packages.props)
+* Code: [Program.cs](../../tasvideos/Program.cs)
+* Code: [ServiceCollectionExtensions.cs](../../TASVideos.Data/ServiceCollectionExtensions.cs)
+* Related ADRs: [ADR-0005](./ADR-0005-movie-parser-plugins.md) - Movie Parser Plugin System
+* Documentation: [.NET 8 Release Notes](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8)

--- a/docs/architecture/ADR-0002-postgresql-database.md
+++ b/docs/architecture/ADR-0002-postgresql-database.md
@@ -1,0 +1,183 @@
+# ADR-0002: PostgreSQL as Primary Database
+
+## Status
+
+Accepted
+
+## Date
+
+2024-11-18 (Documented retrospectively)
+
+## Decision Makers
+
+* TASVideos Development Team
+
+## Context
+
+TASVideos requires a robust relational database to manage:
+- **Complex relationships:** Users, roles, permissions, forums, topics, posts, wiki pages, games, publications, submissions
+- **Full-text search:** Search across wiki pages, forum posts, and publication metadata
+- **Case-insensitive text:** Usernames, page names, and forum topics need case-insensitive comparisons
+- **Data integrity:** Referential integrity, transactions, and ACID compliance
+- **Audit history:** Track all changes to entities with user attribution
+- **Scalability:** Support thousands of users and millions of records
+- **Developer experience:** Good ORM support and tooling
+
+Key requirements:
+- Advanced text search capabilities beyond simple LIKE queries
+- Efficient handling of case-insensitive string comparisons
+- Support for complex queries with multiple joins
+- Native support for JSON data types (for flexible metadata storage)
+- Open-source licensing
+- Active community and long-term viability
+
+## Decision
+
+Use **PostgreSQL** as the primary database with **Entity Framework Core** as the ORM.
+
+### Key Features Utilized
+
+1. **citext Extension** for case-insensitive text
+   - All string columns automatically use citext
+   - No need for LOWER() comparisons in queries
+   - Better index utilization
+
+2. **Full-Text Search (tsvector)**
+   - Native PostgreSQL full-text search
+   - Search across wiki pages and forum posts
+   - Better than LIKE queries for large text corpuses
+
+3. **Snake_case Naming Convention**
+   - Uses `EFCore.NamingConventions` package
+   - Aligns with PostgreSQL best practices
+   - Table: `wiki_pages`, Column: `created_on`
+
+4. **Auto-History Tracking**
+   - Every entity change logged automatically
+   - Tracks: entity type, operation, user, timestamp, old/new values
+   - Implemented via `SaveChanges` override
+
+5. **Npgsql Provider**
+   - High-performance .NET data provider
+   - Version 8.0.4 with EF Core 8.0.6
+
+### Configuration
+
+**Connection Setup:** TASVideos.Data/ServiceCollectionExtensions.cs
+```csharp
+AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+services.AddDbContext<ApplicationDbContext>(options =>
+{
+    options.UseNpgsql(connectionString, b =>
+        b.MigrationsAssembly("TASVideos.Data")
+         .UseQuerySplittingBehavior(QuerySplittingBehavior.SingleQuery))
+        .UseSnakeCaseNamingConvention();
+
+    if (isDevelopment)
+    {
+        options.EnableSensitiveDataLogging();
+    }
+});
+```
+
+**Database Initialization Strategies:** TASVideos.Core/Data/DbInitializer.cs
+1. **Minimal** - `EnsureCreated()` for quick testing
+2. **Migrate** - `Database.MigrateAsync()` for production
+3. **Sample** - Downloads sample data for development
+
+## Alternatives Considered
+
+### SQL Server
+**Pros:**
+- Native Windows integration
+- Excellent tooling (SSMS, Azure Data Studio)
+- Strong .NET integration
+- Mature EF Core support
+
+**Cons:**
+- Limited Linux support (SQL Server on Linux is newer)
+- Licensing costs for production
+- Case-insensitive by default (harder to change)
+- Full-text search setup more complex
+
+**Why not chosen:** PostgreSQL offers better cross-platform support and open-source licensing without compromising features.
+
+### MySQL/MariaDB
+**Pros:**
+- Wide hosting support
+- Mature and stable
+- Good performance
+
+**Cons:**
+- Weaker full-text search (before 5.7)
+- Less advanced SQL features
+- Case sensitivity depends on collation and OS
+- JSON support less mature than PostgreSQL
+
+**Why not chosen:** PostgreSQL's advanced features (citext, tsvector, better JSON support) provide better developer experience.
+
+### MongoDB
+**Pros:**
+- Schema flexibility
+- Good for rapid prototyping
+- Horizontal scaling
+
+**Cons:**
+- Lack of ACID transactions (in earlier versions)
+- No foreign key constraints
+- Complex relational queries difficult
+- ORM support less mature
+
+**Why not chosen:** TASVideos has complex relational data that benefits from SQL and referential integrity.
+
+### SQLite
+**Pros:**
+- Zero configuration
+- Perfect for development
+- Serverless
+
+**Cons:**
+- Limited concurrency (write locks)
+- No citext equivalent
+- Weak full-text search
+- Not suitable for production web apps with multiple users
+
+**Why not chosen:** Insufficient for production workload with concurrent writes.
+
+## Consequences
+
+### Positive
+
+* **Full-text search:** Native tsvector support provides fast, relevant search results
+* **Case-insensitive text:** citext extension eliminates case-handling bugs and improves query performance
+* **Developer experience:** Snake_case naming feels natural in PostgreSQL
+* **Performance:** Excellent query optimizer and index support
+* **Open source:** No licensing costs, active community
+* **Cross-platform:** Runs on Linux, Windows, macOS
+* **JSON support:** Store flexible metadata without schema changes
+* **Auto-history:** Complete audit trail of all data changes
+* **Advanced features:** CTEs, window functions, array types, and more
+
+### Negative
+
+* **Learning curve:** Developers need PostgreSQL-specific knowledge
+* **Hosting:** Requires PostgreSQL hosting (can't use shared MySQL hosting)
+* **Backup complexity:** Need proper backup strategy (pg_dump, WAL archiving)
+* **Case sensitivity:** Default case-sensitive behavior can surprise developers (mitigated by citext)
+* **Migration from other DBs:** Would require effort to switch database systems
+
+### Neutral
+
+* **Version upgrades:** Major PostgreSQL versions may require testing and migration
+* **Extensions:** Reliance on extensions (citext) requires ensuring they're installed
+* **EF Core limitations:** Some PostgreSQL features not exposed through EF Core
+
+## Links
+
+* Code: [ServiceCollectionExtensions.cs](../../TASVideos.Data/ServiceCollectionExtensions.cs)
+* Code: [ApplicationDbContext.cs](../../TASVideos.Data/ApplicationDbContext.cs)
+* Code: [DbInitializer.cs](../../TASVideos.Core/Data/DbInitializer.cs)
+* Related ADRs: [ADR-0001](./ADR-0001-dotnet-aspnetcore.md) - .NET and ASP.NET Core
+* Package: [Npgsql.EntityFrameworkCore.PostgreSQL](https://www.nuget.org/packages/Npgsql.EntityFrameworkCore.PostgreSQL)
+* Package: [EFCore.NamingConventions](https://www.nuget.org/packages/EFCore.NamingConventions)
+* Documentation: [PostgreSQL Documentation](https://www.postgresql.org/docs/)

--- a/docs/architecture/ADR-0003-custom-forum-bbcode-engine.md
+++ b/docs/architecture/ADR-0003-custom-forum-bbcode-engine.md
@@ -1,0 +1,221 @@
+# ADR-0003: Custom BBCode Forum Engine
+
+## Status
+
+Accepted
+
+## Date
+
+2024-11-18 (Documented retrospectively)
+
+## Decision Makers
+
+* TASVideos Development Team
+
+## Context
+
+TASVideos needed a forum system that:
+- Allows users to format posts with rich text (bold, italic, links, images, quotes, code)
+- Prevents XSS attacks from malicious HTML injection
+- Maintains backward compatibility with legacy forum content
+- Supports TASVideos-specific features (video embedding, user mentions, publication links)
+- Provides control over allowed markup and nesting rules
+- Renders quickly on the server side
+- Works without JavaScript for accessibility
+
+Traditional options:
+1. **Allow raw HTML** - Major security risk
+2. **Markdown** - Limited formatting options, no block quotes with attribution
+3. **Third-party forum software** - Difficult to integrate with existing application
+4. **Existing BBCode libraries** - Limited customization, often abandoned
+
+The forum has 15+ years of legacy content that must continue to render correctly.
+
+## Decision
+
+Build a **custom BBCode parser** (`TASVideos.ForumEngine`) with:
+- Tag-based markup similar to HTML but restricted to safe operations
+- Hierarchical parsing with configurable nesting rules
+- Block vs. inline element awareness for proper whitespace handling
+- Extensible tag system for TASVideos-specific features
+- Limited HTML fallback for legacy content
+
+### Tag System Architecture
+
+**Core Parser:** TASVideos.ForumEngine/BbParser.cs
+
+```csharp
+private static readonly Dictionary<string, TagInfo> KnownTags = new()
+{
+    { "b", new() },  // Inline formatting
+    { "i", new() },
+    { "u", new() },
+    { "s", new() },
+    { "quote", new() { IsBlock = true } },  // Block elements
+    { "code", new() { Children = TagInfo.ChildrenAllowed.No, IsBlock = true } },
+    { "url", new() { Children = TagInfo.ChildrenAllowed.IfParam } },
+    { "img", new() { Children = TagInfo.ChildrenAllowed.No } },
+    { "list", new() { Children = TagInfo.ChildrenAllowed.Restricted, IsBlock = true } },
+    { "user", new() },  // TASVideos-specific
+    { "module", new() { IsBlock = true } },  // Dynamic content
+    // ... ~30 tags total
+};
+```
+
+**Tag Configuration:**
+- `IsBlock` - Treats as block element (adds newlines)
+- `Children.No` - No child tags allowed (e.g., code, img)
+- `Children.IfParam` - Children allowed only if parameter given (e.g., [url=...])
+- `Children.Restricted` - Only specific child tags allowed (e.g., list -> *)
+- `AllowSelfNesting` - Controls recursive nesting (default: not allowed)
+
+### Features
+
+1. **Standard BBCode Tags**
+   - Formatting: [b], [i], [u], [s], [sup], [sub]
+   - Structure: [quote], [code], [list], [*], [table], [tr], [td]
+   - Media: [img], [url], [youtube], [archive]
+   - Alignment: [center], [right]
+
+2. **TASVideos-Specific Tags**
+   - [user=UserName] - Link to user profile
+   - [module=ModuleName] - Embed dynamic content
+   - [publication=123M] - Link to publication
+
+3. **Security Features**
+   - URL validation (http/https only)
+   - Image size restrictions
+   - No JavaScript in URLs
+   - HTML entity escaping
+
+4. **Syntax Highlighting**
+   - [code=language] with Prism.js integration
+   - Supports: csharp, javascript, python, sql, etc.
+
+5. **Legacy HTML Support**
+   - Limited safe HTML tags: <b>, <i>, <u>, <s>, <br>, <hr>
+   - Attributes stripped except href on <a>
+   - All other HTML escaped
+
+### Service Layer
+
+**TASVideos.Core/Services/ForumService.cs** provides:
+- Forum/topic/post CRUD operations
+- Position calculation for pagination
+- Topic watching and notifications
+- Poll creation and voting
+- Search integration with PostgreSQL full-text search
+
+**Database Schema:**
+```
+ForumCategory (id, title, ordinal)
+  └─ Forum (id, category_id, name, description)
+      └─ ForumTopic (id, forum_id, title, user_id, poll_id)
+          └─ ForumPost (id, topic_id, user_id, text, post_datetime)
+```
+
+## Alternatives Considered
+
+### Markdown
+**Pros:**
+- Widely known syntax
+- Simple to learn
+- Many parsers available
+
+**Cons:**
+- No quote attribution ([quote=username])
+- Limited formatting options
+- Harder to prevent self-nesting issues
+- No concept of block vs. inline elements
+
+**Why not chosen:** BBCode provides better control over nesting and supports features like attributed quotes that are standard in forums.
+
+### WYSIWYG Editor (TinyMCE, CKEditor)
+**Pros:**
+- Rich editing experience
+- Familiar to users
+- Visual feedback
+
+**Cons:**
+- Generates HTML (security concerns)
+- Requires JavaScript
+- Accessibility issues
+- Complex sanitization needed
+- Large client-side footprint
+
+**Why not chosen:** Server-side BBCode parsing is more secure and accessible.
+
+### Third-Party Forum Software (phpBB, vBulletin)
+**Pros:**
+- Full-featured
+- Battle-tested
+- Large communities
+
+**Cons:**
+- Separate application (data integration difficult)
+- Different user authentication
+- Limited customization
+- Most are PHP-based (different stack)
+
+**Why not chosen:** Need tight integration with TASVideos application and user system.
+
+### Existing BBCode Libraries
+**Pros:**
+- Ready to use
+- Community-tested
+
+**Cons:**
+- Limited customization options
+- Often abandoned
+- Don't support TASVideos-specific features
+- May not handle legacy content correctly
+
+**Why not chosen:** Custom parser provides full control over features and rendering.
+
+### Allow Raw HTML with Sanitization
+**Pros:**
+- Maximum flexibility
+- Familiar to developers
+
+**Cons:**
+- Security risk (sanitization libraries have CVEs)
+- Hard to get right
+- Attack surface is large
+- Requires constant updates
+
+**Why not chosen:** BBCode provides sufficient features with much better security.
+
+## Consequences
+
+### Positive
+
+* **Security:** No XSS vulnerabilities from HTML injection
+* **Control:** Full control over allowed tags and nesting
+* **Performance:** Fast server-side rendering
+* **Accessibility:** Works without JavaScript
+* **Customization:** Easy to add TASVideos-specific features
+* **Legacy support:** Backward compatible with old content
+* **Maintainability:** Single codebase for all forum markup
+* **Syntax highlighting:** Built-in code highlighting for technical discussions
+
+### Negative
+
+* **Custom maintenance:** Must maintain custom parser code
+* **Learning curve:** Users need to learn BBCode syntax
+* **Limited WYSIWYG:** No visual editor (typing raw BBCode)
+* **Tag discovery:** Users may not know all available tags
+* **Testing burden:** Must test all tag combinations and nesting scenarios
+
+### Neutral
+
+* **BBCode familiarity:** Some users know BBCode from other forums, others don't
+* **Preview needed:** Users should preview before posting to see final rendering
+* **Documentation:** Need to document all available tags and usage
+
+## Links
+
+* Code: [BbParser.cs](../../TASVideos.ForumEngine/BbParser.cs)
+* Code: [ForumService.cs](../../TASVideos.Core/Services/ForumService.cs)
+* Code: [Forum entities](../../TASVideos.Data/Entity/Forum/)
+* Related ADRs: [ADR-0004](./ADR-0004-custom-wiki-engine.md) - Wiki Engine Architecture
+* Related ADRs: [ADR-0007](./ADR-0007-permission-based-authorization.md) - Authentication/Authorization

--- a/docs/architecture/ADR-0004-custom-wiki-engine.md
+++ b/docs/architecture/ADR-0004-custom-wiki-engine.md
@@ -1,0 +1,294 @@
+# ADR-0004: Custom Wiki Engine with Revision History
+
+## Status
+
+Accepted
+
+## Date
+
+2024-11-18 (Documented retrospectively)
+
+## Decision Makers
+
+* TASVideos Development Team
+
+## Context
+
+TASVideos needed a wiki system that:
+- Documents game strategies, techniques, and platform information
+- Supports structured content with headings, lists, tables, links
+- Embeds dynamic content (recent submissions, publication lists, etc.)
+- Tracks complete revision history for accountability and rollback
+- Links pages together with automatic broken link detection
+- Controls editing permissions (system pages vs. user pages)
+- Performs full-text search across all content
+- Handles page moves and renames with reference updates
+
+Requirements:
+- **Revision tracking:** Every edit must be preserved with author and timestamp
+- **Dynamic modules:** Embed live data (e.g., "10 most recent submissions")
+- **Link management:** Track page references and detect broken links
+- **Hierarchical pages:** Support subpages (e.g., "GameResources/NES/SMB")
+- **Soft deletes:** Allow page deletion and restoration
+- **Permission-based editing:** Different pages have different edit requirements
+- **Table of contents:** Auto-generate TOC from headings
+
+Traditional wiki engines (MediaWiki, DokuWiki) don't integrate well with .NET applications and lack the dynamic module system needed for TASVideos.
+
+## Decision
+
+Build a **custom wiki engine** (`TASVideos.WikiEngine`) with:
+- Custom markup language optimized for TASVideos content
+- AST (Abstract Syntax Tree) based parser
+- Revision-based storage (every edit creates new revision)
+- Module system for embedding dynamic content
+- Automatic link tracking and broken link detection
+
+### Architecture
+
+**Parser:** TASVideos.WikiEngine/NewParser.cs
+- Lexical analysis and recursive descent parsing
+- Generates AST (Abstract Syntax Tree)
+- Node types in `NodeImplementations/`:
+  - Text, Headings, Lists, Tables
+  - Links (internal, external, interwiki)
+  - Modules (dynamic content)
+  - Formatting (bold, italic, etc.)
+
+**Example Markup:**
+```wiki
+!!! Game Resources / NES / Super Mario Bros.
+
+%%MODULE SubpageNavigation%%
+
+[h2]Overview[/h2]
+
+This page documents techniques for Super Mario Bros. speedruns.
+
+[ul]
+[li][link=/path|Link text][/li]
+[li]__Bold text__[/li]
+[/ul]
+
+%%MODULE LatestPublications|limit=5%%
+```
+
+### Service Layer
+
+**TASVideos.Core/Services/Wiki/WikiPages.cs** provides:
+```csharp
+public interface IWikiPages
+{
+    // Page operations
+    Task<bool> Exists(string? pageName, bool includeDeleted = false);
+    ValueTask<IWikiPage?> Page(string? pageName, int? revisionId = null);
+    Task<IWikiPage?> Add(WikiCreateRequest addRequest);
+    Task<IWikiPage?> Edit(WikiEditRequest editRequest);
+
+    // Page management
+    Task<bool> Move(string originalName, string destinationName, int authorId);
+    Task<int> Delete(string pageName);
+    Task<bool> Undelete(string pageName);
+
+    // Link tracking
+    Task<IReadOnlyCollection<WikiOrphan>> Orphans();
+    Task<IReadOnlyCollection<WikiPageReferral>> BrokenLinks();
+    Task<IReadOnlyCollection<WikiPageReferral>> Referrals(string pageName);
+
+    // Search
+    Task<ICollection<IWikiPage>> AllSubpagesOf(string path);
+    Task<ICollection<WikiSearchResult>> Search(WikiSearchModel search);
+}
+```
+
+### Database Schema
+
+**Revision-Based Storage:**
+```
+wiki_pages (composite primary key: page_name, revision)
+├─ page_name (text, citext)
+├─ revision (int)
+├─ markup (text)
+├─ author_id (int)
+├─ create_timestamp (datetime)
+├─ is_deleted (bool)
+├─ page_data (jsonb) - Structured metadata
+└─ ...
+
+wiki_page_referral
+├─ referrer (text) - Page that contains the link
+├─ referral (text) - Page being linked to
+└─ index on (referral) for finding broken links
+```
+
+**Key Design Decisions:**
+1. **Composite key (page_name, revision):** Every edit is a new row
+2. **Soft deletes:** `is_deleted` flag instead of DELETE
+3. **citext columns:** Case-insensitive page names
+4. **Referral tracking:** Separate table for link graph
+
+### Module System
+
+Modules are dynamic components embedded in wiki pages:
+
+**Built-in Modules:**
+- `SubpageNavigation` - Breadcrumb trail
+- `LatestPublications` - Recent TAS publications
+- `LatestSubmissions` - Submissions in queue
+- `GameList` - List of games for a platform
+- `PlayerPointsTable` - Player ranking
+- `ListRoles` - User roles and permissions
+
+**Module Execution:**
+- Parsed from markup: `%%MODULE ModuleName|param=value%%`
+- Executed at render time (not cached in markup)
+- Has access to database and services via DI
+- Supports parameters for customization
+
+### Features
+
+1. **Full Revision History**
+   - Every edit preserved with author and timestamp
+   - View any historical revision
+   - Compare revisions (diff view)
+   - Rollback to previous revision
+
+2. **Page Operations**
+   - Create, edit, delete, undelete
+   - Move (rename) with subpage handling
+   - Duplicate detection
+
+3. **Link Management**
+   - Automatic referral tracking
+   - Broken link detection
+   - Orphan page detection
+   - "What links here" functionality
+
+4. **Search**
+   - Full-text search using PostgreSQL tsvector
+   - Search by page name or content
+   - Filter by author or date
+
+5. **Permissions**
+   - System pages: Require `EditSystemPages` permission
+   - Game resources: Require `EditGameResources` permission
+   - Basic pages: Require `EditWikiPages` permission
+
+6. **Table of Contents**
+   - Auto-generated from headings
+   - Hierarchical structure
+   - Jump links
+
+## Alternatives Considered
+
+### MediaWiki
+**Pros:**
+- Industry standard (Wikipedia)
+- Proven scalability
+- Rich feature set
+- Large community
+
+**Cons:**
+- PHP-based (different stack)
+- Complex to integrate with .NET app
+- Separate user database
+- No module system for TASVideos features
+- Heavyweight setup
+
+**Why not chosen:** Integration challenges and inability to embed TASVideos-specific dynamic content.
+
+### Markdown with Git Backend
+**Pros:**
+- Simple syntax
+- Git provides version control
+- Developer-friendly
+
+**Cons:**
+- No dynamic modules
+- Git not designed for web editing
+- Merge conflicts on concurrent edits
+- No link tracking
+- Limited formatting options
+
+**Why not chosen:** Doesn't support dynamic content embedding and concurrent editing is problematic.
+
+### Existing .NET Wiki Engines
+**Pros:**
+- Native .NET integration
+- Some options available
+
+**Cons:**
+- Most are abandoned or unmaintained
+- Don't support custom module system
+- Limited customization
+- May not handle TASVideos-specific requirements
+
+**Why not chosen:** Need for custom modules and long-term maintainability.
+
+### Notion/Confluence API
+**Pros:**
+- Modern UI
+- Rich features
+- Hosted solution
+
+**Cons:**
+- External dependency
+- Ongoing costs
+- Limited customization
+- Can't embed TASVideos-specific data
+- Vendor lock-in
+
+**Why not chosen:** Need full control and integration with TASVideos data.
+
+### DokuWiki
+**Pros:**
+- File-based (no database)
+- Simple setup
+- Good plugin system
+
+**Cons:**
+- PHP-based
+- File storage problematic for multiple servers
+- Separate auth system
+- Plugin system not suitable for TASVideos modules
+
+**Why not chosen:** Integration challenges and scaling issues with file-based storage.
+
+## Consequences
+
+### Positive
+
+* **Full control:** Complete control over markup syntax and features
+* **Revision history:** Every edit preserved with full attribution
+* **Dynamic content:** Modules can embed live data from TASVideos database
+* **Link tracking:** Automatic broken link detection and "what links here"
+* **Integration:** Deep integration with TASVideos authentication and permissions
+* **Search:** PostgreSQL full-text search across all content
+* **Performance:** Optimized for TASVideos use cases
+* **Hierarchical pages:** Natural support for subpages
+* **Soft deletes:** Easy to recover accidentally deleted pages
+
+### Negative
+
+* **Custom maintenance:** Must maintain custom parser and renderer
+* **Learning curve:** Users need to learn TASVideos wiki syntax
+* **Limited WYSIWYG:** No visual editor (typing raw markup)
+* **Markup documentation:** Need comprehensive syntax documentation
+* **Migration complexity:** Hard to migrate to another wiki system
+* **Testing burden:** Must test all markup combinations
+* **Storage overhead:** Every revision stored separately (high storage for large pages)
+
+### Neutral
+
+* **Syntax differences:** Similar to but not identical to MediaWiki syntax
+* **Module development:** Adding new modules requires code changes
+* **Preview essential:** Users should preview before saving
+
+## Links
+
+* Code: [NewParser.cs](../../TASVideos.WikiEngine/NewParser.cs)
+* Code: [WikiPages.cs](../../TASVideos.Core/Services/Wiki/WikiPages.cs)
+* Code: [Wiki entities](../../TASVideos.Data/Entity/WikiPage.cs)
+* Code: [Modules](../../TASVideos.Core/Services/Wiki/Modules/)
+* Related ADRs: [ADR-0003](./ADR-0003-custom-forum-bbcode-engine.md) - Forum Engine
+* Related ADRs: [ADR-0007](./ADR-0007-permission-based-authorization.md) - Authentication/Authorization

--- a/docs/architecture/ADR-0005-movie-parser-plugins.md
+++ b/docs/architecture/ADR-0005-movie-parser-plugins.md
@@ -1,0 +1,334 @@
+# ADR-0005: Attribute-Based Movie Parser Plugin System
+
+## Status
+
+Accepted
+
+## Date
+
+2024-11-18 (Documented retrospectively)
+
+## Decision Makers
+
+* TASVideos Development Team
+
+## Context
+
+TASVideos accepts Tool-Assisted Speedrun (TAS) submissions in 23+ different file formats from various emulators:
+- BizHawk (.bk2, .bkm)
+- FCEUX (.fm2, .fm3)
+- Lsnes (.lsmv, .ltm)
+- Snes9x (.smv)
+- PCSX (.pxm)
+- Dolphin (.dtm)
+- And many more...
+
+Each format has:
+- Different file structures (binary, text, zip archives, XML)
+- Different metadata (ROM hash, frame count, author, rerecord count)
+- Different platform identifiers
+- Legacy versions requiring backward compatibility
+
+Requirements:
+- Parse metadata from uploaded movie files
+- Validate file format correctness
+- Extract: platform, ROM hash, frame count, rerecord count, annotations
+- Support adding new formats without modifying core code
+- Handle malformed files gracefully
+- Performance: Parse files quickly (some are MB+ in size)
+
+Adding new emulator support should be:
+1. **Easy:** Just implement parsing logic
+2. **Self-contained:** No registration code needed
+3. **Discoverable:** Automatically detected by system
+
+## Decision
+
+Implement a **reflection-based plugin system** using C# attributes for movie file parser discovery.
+
+### Architecture
+
+**Plugin Interface:** TASVideos.Parsers/IMovieParser.cs
+
+```csharp
+public interface IParser
+{
+    Task<IParseResult> Parse(Stream file, long length);
+}
+
+[AttributeUsage(AttributeTargets.Class)]
+public class FileExtensionAttribute : Attribute
+{
+    public FileExtensionAttribute(string extension)
+    {
+        Extension = extension;
+    }
+
+    public string Extension { get; }
+}
+```
+
+**Example Parser Implementation:**
+
+```csharp
+[FileExtension("bk2")]  // Attribute marks this parser
+internal class Bk2 : Parser, IParser
+{
+    public async Task<IParseResult> Parse(Stream file, long length)
+    {
+        // BizHawk .bk2 format is a zip archive
+        using var archive = new ZipArchive(file, ZipArchiveMode.Read);
+
+        // Extract header
+        var headerEntry = archive.GetEntry("Header.txt");
+        var header = await ParseHeaderFile(headerEntry);
+
+        // Extract input log
+        var inputEntry = archive.GetEntry("Input Log.txt");
+        var frames = await CountFrames(inputEntry);
+
+        return new SuccessResult
+        {
+            SystemCode = header["emuVersion"],
+            FrameCount = frames,
+            RerecordCount = int.Parse(header["rerecordCount"]),
+            // ... more metadata
+        };
+    }
+}
+```
+
+### Plugin Discovery
+
+**Automatic Registration:** TASVideos.Parsers/MovieParser.cs
+
+```csharp
+private static readonly ICollection<Type> ParserTypes =
+    typeof(IParser).Assembly
+        .GetTypes()
+        .Where(t => typeof(IParser).IsAssignableFrom(t))
+        .Where(t => t.IsClass && !t.IsAbstract)
+        .Where(t => t.GetCustomAttributes()
+                     .OfType<FileExtensionAttribute>()
+                     .Any())
+        .ToList();
+
+public async Task<IParseResult> Parse(Stream file, string extension, long length)
+{
+    // Find parser by extension
+    var parserType = ParserTypes
+        .FirstOrDefault(t => GetExtension(t).Equals(
+            extension,
+            StringComparison.OrdinalIgnoreCase));
+
+    if (parserType == null)
+    {
+        return new ErrorResult("Unsupported file format");
+    }
+
+    // Instantiate and parse
+    var parser = (IParser)Activator.CreateInstance(parserType)!;
+    return await parser.Parse(file, length);
+}
+```
+
+### Supported Formats (23+)
+
+| Extension | Emulator | Format Type |
+|-----------|----------|-------------|
+| .bk2 | BizHawk | Zip archive |
+| .bkm | BizHawk (old) | Text |
+| .fm2, .fm3 | FCEUX | Text |
+| .lsmv | Lsnes | Zip archive |
+| .ltm | Lsnes | Text |
+| .smv | Snes9x | Binary |
+| .pxm | PCSX | Binary |
+| .dtm | Dolphin | Binary |
+| .vbm | VisualBoyAdvance | Binary |
+| .jrsr | JPC-RR | Zip archive |
+| ... | ... | ... |
+
+### Base Parser Class
+
+**TASVideos.Parsers/Base/Parser.cs** provides common utilities:
+
+```csharp
+public abstract class Parser
+{
+    protected static string RemoveSuffix(string str, string suffix);
+    protected static string GetString(byte[] bytes, int start, int length);
+    protected static int LittleEndian(byte[] bytes, int start, int length);
+    protected static int BigEndian(byte[] bytes, int start, int length);
+    // ... more helper methods
+}
+```
+
+### Result Types
+
+```csharp
+public interface IParseResult
+{
+    bool Success { get; }
+    string? ErrorMessage { get; }
+    // Metadata fields...
+}
+
+public class SuccessResult : IParseResult
+{
+    public bool Success => true;
+    public string? SystemCode { get; init; }
+    public int FrameCount { get; init; }
+    public int RerecordCount { get; init; }
+    public string? RomHash { get; init; }
+    public string? Annotations { get; init; }
+    // ... more fields
+}
+
+public class ErrorResult : IParseResult
+{
+    public bool Success => false;
+    public string? ErrorMessage { get; init; }
+}
+```
+
+### Service Registration
+
+**TASVideos.Parsers/ServiceCollectionExtensions.cs**
+
+```csharp
+public static IServiceCollection AddTasvideosMovieParsers(
+    this IServiceCollection services)
+{
+    return services.AddSingleton<IMovieParser, MovieParser>();
+}
+```
+
+Singleton lifetime is appropriate because parsers are stateless.
+
+## Alternatives Considered
+
+### Manual Registration
+**Example:**
+```csharp
+services.AddParser(".bk2", typeof(Bk2));
+services.AddParser(".fm2", typeof(Fm2));
+// ... 23 more lines
+```
+
+**Pros:**
+- Explicit and clear
+- Easier to debug
+
+**Cons:**
+- Boilerplate code
+- Easy to forget registration
+- Requires modification of central file
+
+**Why not chosen:** Attribute-based discovery eliminates boilerplate and makes adding parsers trivial.
+
+### Configuration-Based Registration
+**Example (appsettings.json):**
+```json
+{
+  "parsers": [
+    { "extension": "bk2", "type": "TASVideos.Parsers.Bk2" },
+    { "extension": "fm2", "type": "TASVideos.Parsers.Fm2" }
+  ]
+}
+```
+
+**Pros:**
+- Runtime configuration
+- No recompilation needed
+
+**Cons:**
+- Stringly-typed (typos not caught at compile time)
+- Separate configuration to maintain
+- Adds deployment complexity
+
+**Why not chosen:** Parsers are code, not configuration. Compile-time safety is important.
+
+### Convention-Based Discovery
+**Example:** Classes named `*Parser` in `Parsers/` directory
+
+**Pros:**
+- No attributes needed
+- Simple convention
+
+**Cons:**
+- Ambiguous (what if class doesn't follow convention?)
+- How to specify file extension?
+- Less explicit than attributes
+
+**Why not chosen:** Attributes make intent explicit and allow specifying the extension clearly.
+
+### Separate NuGet Packages Per Parser
+**Example:** TASVideos.Parsers.BizHawk, TASVideos.Parsers.FCEUX, etc.
+
+**Pros:**
+- Modular
+- Optional dependencies
+
+**Cons:**
+- Over-engineering for this use case
+- Deployment complexity (23+ packages)
+- Most formats are simple (<100 lines)
+
+**Why not chosen:** All parsers are maintained by TASVideos team. Single package is simpler.
+
+### Dynamic Loading from DLLs
+**Example:** Load parsers from `Plugins/` directory at runtime
+
+**Pros:**
+- True plugin system
+- Third-party plugins possible
+
+**Cons:**
+- Complex security implications
+- Versioning and compatibility issues
+- Deployment and testing complexity
+- Unnecessary for TASVideos (no third-party parsers)
+
+**Why not chosen:** All parsers are first-party. Compile-time linking is safer and simpler.
+
+## Consequences
+
+### Positive
+
+* **Ease of adding parsers:** Create class with attribute, implement `IParser`, done
+* **No registration boilerplate:** Reflection discovers parsers automatically
+* **Compile-time safety:** Type checking ensures correct implementation
+* **Self-documenting:** Attribute makes purpose explicit
+* **Singleton efficiency:** Parsers instantiated once and reused
+* **Testable:** Each parser is independently testable
+* **Base class utilities:** Common parsing functions shared
+* **Error handling:** Uniform error reporting via `IParseResult`
+
+### Negative
+
+* **Reflection overhead:** Discovery uses reflection (one-time cost at startup)
+* **Magic discovery:** Not immediately obvious how parsers are found
+* **Debugging difficulty:** Attribute-based registration harder to trace
+* **No runtime addition:** Can't add parsers without recompiling
+* **Performance:** Each parse instantiates parser (mitigated: parsers are lightweight)
+
+### Neutral
+
+* **Learning curve:** Developers must understand attribute-based pattern
+* **Extension coupling:** File extension tied to class via attribute
+* **Assembly scanning:** Only scans TASVideos.Parsers assembly
+
+## Future Considerations
+
+1. **Caching parser instances:** Consider pooling/caching parser instances if performance profiling shows instantiation overhead
+2. **Async discovery:** If assembly scanning is slow, move to lazy initialization
+3. **Parser versioning:** If emulator formats change, support multiple versions (e.g., `[FileExtension("bk2", Version = 2)]`)
+4. **Validation hooks:** Add optional `Validate()` method to `IParser` for pre-parse validation
+
+## Links
+
+* Code: [IMovieParser.cs](../../TASVideos.Parsers/IMovieParser.cs)
+* Code: [MovieParser.cs](../../TASVideos.Parsers/MovieParser.cs)
+* Code: [Parser implementations](../../TASVideos.Parsers/Parsers/)
+* Code: [ServiceCollectionExtensions.cs](../../TASVideos.Parsers/ServiceCollectionExtensions.cs)
+* Related ADRs: [ADR-0001](./ADR-0001-dotnet-aspnetcore.md) - .NET and ASP.NET Core

--- a/docs/architecture/ADR-0006-minimal-api-with-field-selection.md
+++ b/docs/architecture/ADR-0006-minimal-api-with-field-selection.md
@@ -1,0 +1,429 @@
+# ADR-0006: Minimal API with Field Selection and URL Versioning
+
+## Status
+
+Accepted
+
+## Date
+
+2024-11-18 (Documented retrospectively)
+
+## Decision Makers
+
+* TASVideos Development Team
+
+## Context
+
+TASVideos needed a RESTful API to:
+- Support mobile apps and third-party integrations
+- Provide programmatic access to publications, submissions, games, users
+- Authenticate with JWT Bearer tokens (separate from cookie auth)
+- Support pagination and filtering
+- Allow clients to request only needed fields (reduce payload size)
+- Version the API for future breaking changes
+- Generate OpenAPI/Swagger documentation
+
+API consumers include:
+- Mobile apps with limited bandwidth
+- Discord bots announcing new publications
+- Third-party analytics tools
+- Community-built tools and scripts
+
+Requirements:
+- **Performance:** Fast response times, minimal overhead
+- **Flexibility:** Clients choose which fields to receive
+- **Discoverability:** Self-documenting with Swagger UI
+- **Versioning:** Support multiple API versions simultaneously
+- **Validation:** Request validation with clear error messages
+- **Security:** JWT authentication, prevent over-fetching
+
+Traditional controller-based APIs add overhead and ceremony. With .NET 8, Minimal APIs provide a lightweight alternative.
+
+## Decision
+
+Use **ASP.NET Core Minimal APIs** with **route groups**, **URL-based versioning**, and **field selection**.
+
+### Architecture
+
+**Endpoint Registration:** TASVideos.Api/WebApplicationExtensions.cs
+
+```csharp
+public static IApplicationBuilder UseTasvideosApiEndpoints(
+    this WebApplication app,
+    AppSettings settings)
+{
+    return app.MapPublications()
+        .MapSubmissions()
+        .MapEvents()
+        .MapGames()
+        .MapSystems()
+        .MapUsers()
+        .MapTags()
+        .MapClasses()
+        .MapMigrations();
+}
+```
+
+**Route Group Helper:** TASVideos.Api/Helpers/RouteGroupExtensions.cs
+
+```csharp
+public static RouteGroupBuilder MapApiGroup(
+    this WebApplication app,
+    string groupName)
+{
+    return app.MapGroup($"/api/v1/{groupName.ToLower()}")
+        .WithTags(groupName)
+        .WithOpenApi();
+}
+```
+
+### Example Endpoint
+
+**TASVideos.Api/Endpoints/PublicationsEndpoints.cs:**
+
+```csharp
+internal static class PublicationsEndpoints
+{
+    public static WebApplication MapPublications(this WebApplication app)
+    {
+        var group = app.MapApiGroup("Publications");
+
+        // GET /api/v1/publications/{id}
+        group.MapGet("{id:int}", async (
+            int id,
+            ApplicationDbContext db) =>
+        {
+            var publication = await db.Publications
+                .ToPublicationsResponse()
+                .SingleOrDefaultAsync(p => p.Id == id);
+
+            return ApiResults.OkOr404(publication);
+        })
+        .ProducesFromId<PublicationsResponse>("publication")
+        .WithName("GetPublication");
+
+        // GET /api/v1/publications?search=mario&limit=10
+        group.MapGet("", async (
+            [AsParameters] PublicationsRequest request,
+            ApplicationDbContext db) =>
+        {
+            var query = db.Publications.AsQueryable();
+
+            // Apply filters from request
+            if (!string.IsNullOrWhiteSpace(request.Search))
+            {
+                query = query.Where(p =>
+                    EF.Functions.ILike(p.Title, $"%{request.Search}%"));
+            }
+
+            // Pagination
+            var total = await query.CountAsync();
+            var results = await query
+                .OrderByDescending(p => p.CreateTimestamp)
+                .Skip((request.Page - 1) * request.Limit)
+                .Take(request.Limit)
+                .ToPublicationsResponse()
+                .ToListAsync();
+
+            return new PagedResponse<PublicationsResponse>
+            {
+                Items = results,
+                TotalCount = total,
+                Page = request.Page,
+                Limit = request.Limit
+            };
+        })
+        .ProducesFromRequest<PublicationsRequest, PublicationsResponse>("publications");
+
+        return app;
+    }
+}
+```
+
+### Field Selection
+
+**Feature:** Clients specify which fields to return in response.
+
+**Query Parameter:** `?fields=id,title,authors`
+
+**Implementation:** TASVideos.Api/Helpers/FieldSelection.cs
+
+```csharp
+public static IQueryable<TResponse> SelectFields<TResponse>(
+    this IQueryable<TResponse> query,
+    string? fields)
+{
+    if (string.IsNullOrWhiteSpace(fields))
+    {
+        return query; // Return all fields
+    }
+
+    // Parse requested fields
+    var fieldList = fields.Split(',')
+        .Select(f => f.Trim())
+        .ToList();
+
+    // Use Expression Trees to build dynamic projection
+    var parameter = Expression.Parameter(typeof(TResponse), "x");
+    var bindings = fieldList.Select(field =>
+    {
+        var property = typeof(TResponse).GetProperty(
+            field,
+            BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+
+        if (property == null)
+        {
+            throw new ApiException($"Unknown field: {field}");
+        }
+
+        return Expression.Bind(
+            property,
+            Expression.Property(parameter, property));
+    });
+
+    var memberInit = Expression.MemberInit(
+        Expression.New(typeof(TResponse)),
+        bindings);
+
+    var lambda = Expression.Lambda<Func<TResponse, TResponse>>(
+        memberInit,
+        parameter);
+
+    return query.Select(lambda);
+}
+```
+
+**Example Request:**
+```
+GET /api/v1/publications/1000?fields=id,title,authors
+```
+
+**Response:**
+```json
+{
+  "id": 1000,
+  "title": "Super Mario Bros.",
+  "authors": ["Author1", "Author2"]
+}
+```
+
+### Versioning Strategy
+
+**Current:** URL-based versioning (`/api/v1/...`)
+
+**Future Strategy:**
+1. New version: Create `/api/v2/...` endpoints
+2. Keep v1 running for backward compatibility
+3. Deprecation notice in v1 responses (custom header)
+4. Eventually sunset v1 after migration period
+
+**Benefits:**
+- Simple and explicit
+- Easy to route in reverse proxies
+- Clear in URLs and logs
+- No header parsing required
+
+**OpenAPI:** Separate Swagger docs per version
+
+```csharp
+services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "TASVideos API",
+        Version = "v1",
+        Description = "RESTful API for TASVideos"
+    });
+});
+```
+
+### Authentication
+
+**JWT Bearer Tokens:** TASVideos.Api/ServiceCollectionExtensions.cs
+
+```csharp
+services.AddAuthentication(x =>
+{
+    x.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    x.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+})
+.AddJwtBearer(x =>
+{
+    x.RequireHttpsMetadata = true;
+    x.SaveToken = true;
+    x.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(key),
+        ValidateIssuer = false,
+        ValidateAudience = false,
+        ClockSkew = TimeSpan.Zero
+    };
+});
+```
+
+**Token Generation:** TASVideos.Core/Services/JwtAuthenticator.cs
+
+Users obtain tokens via `/api/v1/auth/token` endpoint with username/password.
+
+### Request Validation
+
+**FluentValidation:** TASVideos.Api/Validators/
+
+```csharp
+public class PublicationsRequestValidator : AbstractValidator<PublicationsRequest>
+{
+    public PublicationsRequestValidator()
+    {
+        RuleFor(x => x.Page)
+            .GreaterThan(0)
+            .WithMessage("Page must be greater than 0");
+
+        RuleFor(x => x.Limit)
+            .InclusiveBetween(1, 100)
+            .WithMessage("Limit must be between 1 and 100");
+    }
+}
+```
+
+Validation errors return `400 Bad Request` with detailed error messages.
+
+### Swagger/OpenAPI Documentation
+
+**Endpoint:** `/api` - Interactive Swagger UI
+
+**Features:**
+- Try endpoints directly from browser
+- See request/response schemas
+- Authentication via JWT token
+- Example requests
+
+## Alternatives Considered
+
+### Controller-Based API
+**Example:**
+```csharp
+[ApiController]
+[Route("api/v1/[controller]")]
+public class PublicationsController : ControllerBase
+{
+    [HttpGet("{id}")]
+    public async Task<ActionResult<PublicationResponse>> Get(int id)
+    {
+        // ...
+    }
+}
+```
+
+**Pros:**
+- Traditional and familiar
+- More structure and conventions
+- Better for large teams
+
+**Cons:**
+- More boilerplate code
+- Slower performance (routing overhead)
+- Unnecessary ceremony for simple endpoints
+
+**Why not chosen:** Minimal APIs are faster and simpler for TASVideos' straightforward API needs.
+
+### GraphQL
+**Pros:**
+- Flexible field selection built-in
+- Single endpoint
+- Strongly typed schema
+
+**Cons:**
+- Steeper learning curve
+- More complex setup
+- Harder to cache
+- Overkill for TASVideos API
+
+**Why not chosen:** REST with field selection provides sufficient flexibility without GraphQL complexity.
+
+### OData
+**Pros:**
+- Standardized query language
+- Rich filtering and sorting
+- Field selection built-in
+
+**Cons:**
+- Complex specification
+- Large payloads
+- Performance issues with complex queries
+- Over-engineered for TASVideos
+
+**Why not chosen:** Custom field selection provides what's needed without OData overhead.
+
+### Header-Based Versioning
+**Example:** `Accept: application/vnd.tasvideos.v1+json`
+
+**Pros:**
+- RESTful purist approach
+- Cleaner URLs
+
+**Cons:**
+- Harder to test (need to set headers)
+- Not visible in URL
+- Harder to route in proxies
+- More complex implementation
+
+**Why not chosen:** URL-based versioning is simpler and more explicit.
+
+### Query Parameter Versioning
+**Example:** `/api/publications?version=1`
+
+**Pros:**
+- Easy to implement
+- Visible in URL
+
+**Cons:**
+- Pollutes query string
+- Easy to omit
+- Less clear than path segment
+
+**Why not chosen:** URL path segment is clearer and more conventional.
+
+## Consequences
+
+### Positive
+
+* **Performance:** Minimal APIs are faster than controllers
+* **Simplicity:** Less boilerplate, easier to read
+* **Field selection:** Reduces payload size for mobile apps
+* **Versioning:** Clear and explicit in URLs
+* **Documentation:** Swagger UI is self-documenting
+* **JWT authentication:** Stateless and scalable
+* **Validation:** FluentValidation provides clear error messages
+* **Route groups:** Clean organization of related endpoints
+
+### Negative
+
+* **Less structure:** No controller conventions to follow
+* **Discovery:** Endpoints spread across multiple files
+* **Middleware:** Some controller features unavailable
+* **Reflection overhead:** Field selection uses reflection (mitigated by caching)
+
+### Neutral
+
+* **Learning curve:** Developers must learn Minimal API patterns
+* **Field selection adoption:** Clients must opt-in to field selection
+* **Versioning commitment:** Must maintain old versions for compatibility
+
+## Future Considerations
+
+1. **Rate limiting:** Add per-user/IP rate limits to prevent abuse
+2. **Caching:** Add response caching for frequently accessed resources
+3. **API v2:** When breaking changes needed, introduce `/api/v2/...`
+4. **WebSockets:** Consider real-time API for live submission updates
+5. **Batch operations:** Support batch requests (e.g., get multiple publications)
+
+## Links
+
+* Code: [WebApplicationExtensions.cs](../../TASVideos.Api/WebApplicationExtensions.cs)
+* Code: [PublicationsEndpoints.cs](../../TASVideos.Api/Endpoints/PublicationsEndpoints.cs)
+* Code: [ServiceCollectionExtensions.cs](../../TASVideos.Api/ServiceCollectionExtensions.cs)
+* Code: [JwtAuthenticator.cs](../../TASVideos.Core/Services/JwtAuthenticator.cs)
+* Related ADRs: [ADR-0001](./ADR-0001-dotnet-aspnetcore.md) - .NET and ASP.NET Core
+* Related ADRs: [ADR-0007](./ADR-0007-permission-based-authorization.md) - Authentication/Authorization
+* Documentation: [Minimal APIs](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis)

--- a/docs/architecture/ADR-0007-permission-based-authorization.md
+++ b/docs/architecture/ADR-0007-permission-based-authorization.md
@@ -1,0 +1,433 @@
+# ADR-0007: Permission-Based Authorization with ASP.NET Core Identity
+
+## Status
+
+Accepted
+
+## Date
+
+2024-11-18 (Documented retrospectively)
+
+## Decision Makers
+
+* TASVideos Development Team
+
+## Context
+
+TASVideos has complex authorization requirements:
+- **Granular permissions:** Different actions require different permissions (judge submissions, edit wiki, moderate forums, etc.)
+- **Role composition:** Users can have multiple roles (e.g., Judge + Publisher)
+- **Permission groups:** Permissions logically grouped by area (wiki, forums, submissions, admin)
+- **Dual authentication:** Cookie-based for web UI, JWT tokens for API
+- **Security:** Strong password requirements, email confirmation, secure password hashing
+- **User management:** Admins need to assign roles and permissions
+- **Audit trail:** Track who has which permissions and when granted
+
+Authorization examples:
+- Only Judges can judge submissions
+- Only Publishers can publish movies
+- Only Admins can edit system wiki pages
+- Anyone with "CreateForumPosts" can create forum posts
+- Users can edit their own profile, but only Admins can edit others' profiles
+
+Traditional role-based authorization (RBAC) has limitations:
+- Roles like "Moderator" are too coarse-grained
+- Hard to compose roles (e.g., Judge + Publisher)
+- Adding new permissions requires new roles or modifying existing ones
+
+Permission-based authorization is more flexible:
+- Fine-grained control
+- Composable (users can have multiple roles, each with multiple permissions)
+- Easy to add new permissions without role changes
+
+## Decision
+
+Implement **permission-based authorization** built on **ASP.NET Core Identity** with:
+- Permission enum for compile-time safety
+- Many-to-many: Users -> Roles -> Permissions
+- Claims-based authorization for performance
+- Dual authentication: Cookies (web) + JWT (API)
+- Strong password requirements following OWASP 2023 guidelines
+
+### Permission Model
+
+**Permission Enum:** TASVideos.Data/Entity/PermissionTo.cs
+
+```csharp
+public enum PermissionTo
+{
+    // User permissions (1-99)
+    CreateForumPosts = 1,
+    EditHomePage = 2,
+    SubmitMovies = 3,
+    RateMovies = 4,
+    VoteOnPolls = 5,
+    SendPrivateMessages = 6,
+    // ...
+
+    // Wiki permissions (100-199)
+    EditWikiPages = 100,
+    EditGameResources = 101,
+    EditSystemPages = 102,
+    EditRoles = 103,
+    CreateNewWikiPages = 104,
+    DeleteWikiPages = 105,
+    // ...
+
+    // Queue Maintenance (200-299)
+    JudgeSubmissions = 200,
+    PublishMovies = 201,
+    EditSubmissions = 202,
+    CancelSubmissions = 203,
+    // ...
+
+    // Publication Maintenance (300-399)
+    SetPublicationClass = 300,
+    CatalogMovies = 301,
+    EditPublicationMetadata = 302,
+    ObsoleteMovies = 303,
+    // ...
+
+    // Forum Moderation (400-499)
+    EditUsersForumPosts = 400,
+    DeleteForumPosts = 401,
+    CreateForumCategory = 402,
+    LockTopics = 403,
+    // ...
+
+    // User Administration (500-599)
+    DeleteRoles = 500,
+    EditUsers = 502,
+    AssignRoles = 504,
+    ViewPrivateMessages = 505,
+    // ...
+
+    // Admin (9000+)
+    SeeDiagnostics = 9001,
+    SeeEmails = 9002,
+    AccessAdminDashboard = 9003,
+}
+```
+
+**Design Rationale:**
+- Numeric ranges group related permissions (1xx for wiki, 2xx for submissions, etc.)
+- Enum provides compile-time safety (no typos)
+- Gaps allow future expansion within each category
+- Descriptive names make intent clear
+
+### Database Schema
+
+**Entity Relationships:**
+```
+User (AspNetUsers)
+  └─ UserRole (many-to-many join table)
+      └─ Role (AspNetRoles)
+          └─ RolePermission (many-to-many join table)
+              └─ Permission (PermissionTo enum)
+```
+
+**Key Tables:**
+- `AspNetUsers` - User accounts (from Identity)
+- `AspNetRoles` - Role definitions (e.g., "Judge", "Publisher")
+- `AspNetUserRoles` - User-to-Role mapping
+- `RolePermission` - Role-to-Permission mapping
+- Permissions stored as integers (enum values)
+
+### Authentication Setup
+
+**ASP.NET Core Identity:** tasvideos/Extensions/ServiceCollectionExtensions.cs
+
+```csharp
+services.AddIdentity<User, Role>(config =>
+{
+    // Email confirmation
+    config.SignIn.RequireConfirmedEmail = env.IsProduction() || env.IsStaging();
+
+    // Password requirements (OWASP 2023)
+    config.Password.RequiredLength = 12;
+    config.Password.RequireDigit = false;
+    config.Password.RequireLowercase = false;
+    config.Password.RequireUppercase = false;
+    config.Password.RequireNonAlphanumeric = false;
+    config.Password.RequiredUniqueChars = 4;
+
+    // Email
+    config.User.RequireUniqueEmail = true;
+
+    // Username characters (support international names)
+    config.User.AllowedUserNameCharacters +=
+        "āàâãáäéèëêíîïóôöúüûý£ŉçÑñ";
+})
+.AddEntityFrameworkStores<ApplicationDbContext>()
+.AddDefaultTokenProviders();
+
+// Password hashing (OWASP 2023 recommendation)
+services.Configure<PasswordHasherOptions>(options =>
+    options.IterationCount = 720_000);
+```
+
+**Dual Authentication:**
+
+1. **Cookie Authentication (Web UI)**
+   - 90-day expiration
+   - Sliding expiration (renewed on activity)
+   - Persistent login option
+
+2. **JWT Bearer (API)**
+   - Stateless tokens
+   - Short expiration (configurable)
+   - Refresh token flow (optional)
+
+**Configuration:** TASVideos.Api/ServiceCollectionExtensions.cs
+
+```csharp
+services.AddAuthentication(x =>
+{
+    x.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    x.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+})
+.AddCookie(options =>
+{
+    options.LoginPath = "/Account/Login";
+    options.ExpireTimeSpan = TimeSpan.FromDays(90);
+    options.SlidingExpiration = true;
+})
+.AddJwtBearer(x =>
+{
+    x.RequireHttpsMetadata = true;
+    x.SaveToken = true;
+    x.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(key),
+        ValidateIssuer = false,
+        ValidateAudience = false,
+        ClockSkew = TimeSpan.Zero
+    };
+});
+```
+
+### Authorization Usage
+
+**Razor Pages:**
+```csharp
+[RequirePermission(PermissionTo.JudgeSubmissions)]
+public class JudgeSubmissionPage : PageModel
+{
+    // Only users with JudgeSubmissions permission can access
+}
+```
+
+**Service Layer:**
+```csharp
+public async Task<bool> CanUserJudge(int userId)
+{
+    return await _userManager.HasPermission(
+        userId,
+        PermissionTo.JudgeSubmissions);
+}
+```
+
+**View Templates:**
+```html
+@if (User.Has(PermissionTo.EditWikiPages))
+{
+    <a href="/wiki/edit/@Model.PageName">Edit</a>
+}
+```
+
+### Service Implementations
+
+**User Management:** TASVideos.Core/Services/UserManager.cs
+
+```csharp
+public interface IUserManager
+{
+    Task<bool> HasPermission(int userId, PermissionTo permission);
+    Task<IEnumerable<PermissionTo>> GetUserPermissions(int userId);
+    Task<bool> IsInRole(int userId, string roleName);
+}
+```
+
+**Role Management:** TASVideos.Core/Services/RoleService.cs
+
+```csharp
+public interface IRoleService
+{
+    Task<IEnumerable<Role>> GetAllRoles();
+    Task<Role?> GetRole(int roleId);
+    Task CreateRole(string name, string description);
+    Task AddPermissionToRole(int roleId, PermissionTo permission);
+    Task RemovePermissionFromRole(int roleId, PermissionTo permission);
+}
+```
+
+**Claims-Based Caching:**
+
+When user logs in, all permissions are loaded into claims:
+```csharp
+var permissions = await GetUserPermissions(user.Id);
+var claims = permissions.Select(p =>
+    new Claim("permission", ((int)p).ToString()));
+
+await _signInManager.SignInWithClaimsAsync(user, claims);
+```
+
+This avoids database queries on every permission check.
+
+## Alternatives Considered
+
+### Role-Based Authorization Only
+**Example:** Roles like "Moderator", "Admin", "Judge"
+
+**Pros:**
+- Simpler to understand
+- Built into ASP.NET Core Identity
+
+**Cons:**
+- Too coarse-grained (what if someone is Judge but not Publisher?)
+- Role explosion (need Judge, Publisher, JudgeAndPublisher, etc.)
+- Hard to add new permissions without new roles
+
+**Why not chosen:** Insufficient granularity for TASVideos' complex requirements.
+
+### Policy-Based Authorization
+**Example:**
+```csharp
+services.AddAuthorization(options =>
+{
+    options.AddPolicy("CanJudge", policy =>
+        policy.RequireClaim("permission", "200"));
+});
+```
+
+**Pros:**
+- Flexible
+- Built into ASP.NET Core
+
+**Cons:**
+- Stringly-typed ("permission", "200")
+- Hard to discover available policies
+- Policies defined separately from usage
+
+**Why not chosen:** Permission enum provides better compile-time safety.
+
+### Attribute-Based Access Control (ABAC)
+**Example:** Rules based on attributes (user.department == "moderation")
+
+**Pros:**
+- Very flexible
+- Dynamic rules
+
+**Cons:**
+- Complex to implement
+- Harder to reason about
+- Overkill for TASVideos
+- Performance overhead (rule evaluation)
+
+**Why not chosen:** TASVideos has well-defined permissions, not dynamic rules.
+
+### Third-Party Auth (Auth0, Okta)
+**Pros:**
+- Hosted solution
+- Advanced features (SSO, MFA)
+- Offload security responsibility
+
+**Cons:**
+- Ongoing costs
+- External dependency
+- Less control
+- Integration complexity
+- Data residency concerns
+
+**Why not chosen:** ASP.NET Core Identity is sufficient and free.
+
+### Custom Authentication System
+**Example:** Build from scratch with hashed passwords
+
+**Pros:**
+- Full control
+- No dependencies
+
+**Cons:**
+- Security risk (easy to get wrong)
+- Maintenance burden
+- Missing features (password reset, email confirmation, etc.)
+- Reinventing the wheel
+
+**Why not chosen:** ASP.NET Core Identity is battle-tested and secure.
+
+## Consequences
+
+### Positive
+
+* **Granular control:** Fine-grained permissions for specific actions
+* **Composable roles:** Users can have multiple roles with different permissions
+* **Compile-time safety:** Enum prevents typos and provides IntelliSense
+* **Organized permissions:** Numeric grouping makes permissions discoverable
+* **Claims-based performance:** Permissions cached in claims (no DB queries)
+* **Extensibility:** Easy to add new permissions by extending enum
+* **Audit trail:** Database tracks role assignments and changes
+* **Strong security:** OWASP-compliant password hashing and requirements
+* **Dual authentication:** Supports both web and API clients
+* **International support:** Usernames support non-ASCII characters
+
+### Negative
+
+* **Complexity:** More complex than simple role-based auth
+* **Migration required:** Adding permissions requires database migration
+* **Enum growth:** Permission enum will grow over time
+* **Claims invalidation:** Permissions changes require re-login (mitigated: rare occurrence)
+* **Learning curve:** Developers must understand permission model
+
+### Neutral
+
+* **Permission discovery:** Developers must check enum for available permissions
+* **Role naming:** Role names are convention-based (no enforcement)
+* **Permission assignment:** Admins must understand which permissions to grant
+
+## Security Considerations
+
+1. **Password Hashing:**
+   - PBKDF2 with 720,000 iterations (OWASP 2023)
+   - Automatic rehashing on login if iteration count changes
+
+2. **Password Requirements:**
+   - Minimum 12 characters
+   - No complexity requirements (OWASP guideline)
+   - At least 4 unique characters
+
+3. **Email Confirmation:**
+   - Required in production/staging
+   - Prevents fake accounts
+
+4. **JWT Security:**
+   - HTTPS required
+   - Short expiration
+   - Symmetric key signing
+
+5. **Cookie Security:**
+   - HttpOnly flag
+   - Secure flag (HTTPS only)
+   - SameSite=Strict
+
+## Future Considerations
+
+1. **Two-Factor Authentication (2FA):** Add support for TOTP/authenticator apps
+2. **OAuth Providers:** Allow login with GitHub, Google, Discord
+3. **Permission history:** Track when permissions were granted/revoked
+4. **Permission groups:** Group related permissions for bulk assignment
+5. **Time-based permissions:** Temporary permission grants (e.g., "Judge for 30 days")
+
+## Links
+
+* Code: [PermissionTo.cs](../../TASVideos.Data/Entity/PermissionTo.cs)
+* Code: [User.cs](../../TASVideos.Data/Entity/User.cs)
+* Code: [Role.cs](../../TASVideos.Data/Entity/Role.cs)
+* Code: [UserManager.cs](../../TASVideos.Core/Services/UserManager.cs)
+* Code: [RoleService.cs](../../TASVideos.Core/Services/RoleService.cs)
+* Code: [ServiceCollectionExtensions.cs](../../tasvideos/Extensions/ServiceCollectionExtensions.cs)
+* Related ADRs: [ADR-0002](./ADR-0002-postgresql-database.md) - PostgreSQL Database
+* Related ADRs: [ADR-0006](./ADR-0006-minimal-api-with-field-selection.md) - API Strategy
+* Documentation: [ASP.NET Core Identity](https://learn.microsoft.com/en-us/aspnet/core/security/authentication/identity)
+* Documentation: [OWASP Password Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,97 @@
+# Architecture Decision Records (ADRs)
+
+This directory contains Architecture Decision Records (ADRs) documenting key architectural decisions made in the TASVideos project.
+
+## What are ADRs?
+
+Architecture Decision Records capture important architectural decisions along with their context and consequences. They help:
+- **New developers** understand why decisions were made
+- **Current team** remember the reasoning behind choices
+- **Future maintainers** evaluate whether decisions still make sense
+
+## ADR Format
+
+Each ADR follows a consistent structure:
+- **Status:** Proposed, Accepted, Deprecated, or Superseded
+- **Context:** The issue motivating the decision
+- **Decision:** The chosen solution
+- **Alternatives Considered:** Other options evaluated
+- **Consequences:** Positive, negative, and neutral outcomes
+
+## Creating New ADRs
+
+Use [template.md](./template.md) when creating new ADRs.
+
+## Current ADRs
+
+### Core Technology Stack
+
+- [ADR-0001: Use .NET 8 and ASP.NET Core with Razor Pages](./ADR-0001-dotnet-aspnetcore.md)
+  - **Decision:** Use .NET 8.0 LTS with ASP.NET Core Razor Pages for web UI and Minimal APIs for REST endpoints
+  - **Context:** Modern, performant framework with long-term support and strong typing
+  - **Status:** Accepted
+
+- [ADR-0002: PostgreSQL as Primary Database](./ADR-0002-postgresql-database.md)
+  - **Decision:** Use PostgreSQL with Entity Framework Core, leveraging citext and full-text search
+  - **Context:** Need for robust relational database with advanced text search and case-insensitive comparisons
+  - **Status:** Accepted
+
+### Custom Engines
+
+- [ADR-0003: Custom BBCode Forum Engine](./ADR-0003-custom-forum-bbcode-engine.md)
+  - **Decision:** Build custom BBCode parser with hierarchical tag system and configurable nesting rules
+  - **Context:** Secure forum markup supporting TASVideos-specific features and legacy content
+  - **Status:** Accepted
+
+- [ADR-0004: Custom Wiki Engine with Revision History](./ADR-0004-custom-wiki-engine.md)
+  - **Decision:** Custom wiki markup parser with AST, revision-based storage, and dynamic module system
+  - **Context:** Wiki supporting dynamic content embedding and complete revision history
+  - **Status:** Accepted
+
+### Plugin & API Architecture
+
+- [ADR-0005: Attribute-Based Movie Parser Plugin System](./ADR-0005-movie-parser-plugins.md)
+  - **Decision:** Reflection-based plugin discovery using C# attributes for 23+ movie file formats
+  - **Context:** Extensible system for parsing various TAS movie file formats
+  - **Status:** Accepted
+
+- [ADR-0006: Minimal API with Field Selection and URL Versioning](./ADR-0006-minimal-api-with-field-selection.md)
+  - **Decision:** Use ASP.NET Core Minimal APIs with route groups, URL versioning (`/api/v1/`), and optional field selection
+  - **Context:** Lightweight REST API for mobile apps and third-party integrations
+  - **Status:** Accepted
+
+### Security & Authorization
+
+- [ADR-0007: Permission-Based Authorization with ASP.NET Core Identity](./ADR-0007-permission-based-authorization.md)
+  - **Decision:** Fine-grained permission system with enum-based permissions, composable roles, and dual authentication (cookies + JWT)
+  - **Context:** Complex authorization requirements with granular permission control
+  - **Status:** Accepted
+
+## ADR Index by Topic
+
+### Technology Choices
+- ADR-0001 (Platform), ADR-0002 (Database)
+
+### Content Management
+- ADR-0003 (Forum), ADR-0004 (Wiki)
+
+### Extensibility
+- ADR-0005 (Parsers)
+
+### API Design
+- ADR-0006 (REST API)
+
+### Security
+- ADR-0007 (Auth/Authz)
+
+## Related Documentation
+
+- [DESIGN-SPEC.md](../DESIGN-SPEC.md) - Frontend design specification
+- [README.md](../../README.md) - Project overview and setup guide
+
+## Questions?
+
+For questions about architectural decisions or to propose changes, please:
+1. Review the existing ADRs
+2. Check the related code references
+3. Open an issue or discussion on GitHub

--- a/docs/architecture/template.md
+++ b/docs/architecture/template.md
@@ -1,0 +1,68 @@
+# ADR-XXXX: [Short descriptive title]
+
+## Status
+
+[Proposed | Accepted | Deprecated | Superseded]
+
+## Date
+
+YYYY-MM-DD
+
+## Decision Makers
+
+* [Name/Team]
+* [Name/Team]
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+Describe the forces at play, including:
+- Technical concerns
+- Business requirements
+- User needs
+- Team capabilities
+- Time/resource constraints
+- External dependencies
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+Describe the chosen solution and why it was selected over alternatives.
+
+## Alternatives Considered
+
+What other options were evaluated?
+
+For each alternative:
+- Brief description
+- Pros and cons
+- Why it was not chosen
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?
+
+### Positive
+
+* List benefits
+* Improvements to the system
+* Problems solved
+
+### Negative
+
+* Tradeoffs made
+* New limitations introduced
+* Technical debt incurred
+
+### Neutral
+
+* Changes that are neither clearly positive nor negative
+
+## Links
+
+* Related ADRs: [ADR-XXXX](./ADR-XXXX.md)
+* Code references: [File/Class/Method](../path/to/code)
+* External documentation: [Link](https://example.com)
+* Related issues/PRs: #123


### PR DESCRIPTION
Created comprehensive ADR documentation to help new developers understand the architectural decisions behind TASVideos. This addresses the gap in backend architecture documentation (frontend has DESIGN-SPEC.md).

Added documentation:
- ADR-0001: Use .NET 8 and ASP.NET Core with Razor Pages
- ADR-0002: PostgreSQL as Primary Database
- ADR-0003: Custom BBCode Forum Engine
- ADR-0004: Custom Wiki Engine with Revision History
- ADR-0005: Attribute-Based Movie Parser Plugin System
- ADR-0006: Minimal API with Field Selection and URL Versioning
- ADR-0007: Permission-Based Authorization with ASP.NET Core Identity

Each ADR includes:
- Context explaining the problem being solved
- Decision with implementation details
- Alternatives considered with pros/cons
- Consequences (positive, negative, neutral)
- Links to relevant code and related ADRs

Benefits:
- New developers understand "why" behind architectural choices
- Historical context preserved for future reference
- Easier to revisit and evaluate past decisions
- Template provided for documenting future decisions

Also updated README.md with Documentation section linking to ADRs.