### PR TITLE
Fix HttpClient socket exhaustion anti-pattern in QueueService

### DIFF
--- a/TASVideos.Core/Services/QueueService.cs
+++ b/TASVideos.Core/Services/QueueService.cs
@@ -101,6 +101,7 @@ public interface IQueueService
 internal class QueueService(
 	AppSettings settings,
 	ApplicationDbContext db,
+	IHttpClientFactory httpClientFactory,
 	IYoutubeSync youtubeSync,
 	ITASVideoAgent tva,
 	IWikiPages wikiPages,
@@ -671,7 +672,7 @@ internal class QueueService(
 				try
 				{
 					var youtubeEmbedImageLink = "https://i.ytimg.com/vi/" + submission.EncodeEmbedLink!.Split('/').Last() + "/hqdefault.jpg";
-					using var client = new HttpClient();
+					var client = httpClientFactory.CreateClient();
 					var response = await client.GetAsync(youtubeEmbedImageLink);
 					if (response.IsSuccessStatusCode)
 					{


### PR DESCRIPTION
CRITICAL FIX: Replace direct HttpClient instantiation with IHttpClientFactory to prevent socket exhaustion under load.

Changes:
- Inject IHttpClientFactory into QueueService constructor
- Replace `using var client = new HttpClient()` with factory pattern at line 674
- Remove using statement (factory manages HttpClient lifecycle)

Impact:
- Prevents socket exhaustion caused by 240-second TIME_WAIT on disposed sockets
- Improves performance under load through connection pooling
- Aligns with established pattern in BlueskyDistributor, DiscordDistributor, GoogleAuthService, and YouTubeSync

Fixes socket exhaustion that could lead to SocketException under high traffic.