### PR TITLE
Fix Cross-Origin-Resource-Policy security issue with conditional poli…

### DIFF
--- a/CORP_SECURITY_IMPROVEMENTS.md
+++ b/CORP_SECURITY_IMPROVEMENTS.md
@@ -1,0 +1,78 @@
+# Cross-Origin-Resource-Policy Security Improvements
+
+## Overview
+This document describes the security improvements made to the Cross-Origin-Resource-Policy (CORP) implementation in TASVideos.
+
+## Problem Statement
+Previously, the application set `Cross-Origin-Resource-Policy: cross-origin` for all responses, which posed a security risk:
+- Authenticated content could be accessed cross-origin
+- Sensitive user data could potentially be leaked through cross-origin requests
+- No differentiation between public and private resources
+
+## Solution
+Implemented conditional CORP headers based on authentication status and content type:
+
+### Policy Matrix
+
+| Condition | CORP Value | Rationale |
+|-----------|-----------|-----------|
+| **Authenticated Users** | `same-origin` | Maximum protection for any content viewed by logged-in users. Prevents cross-origin access to authenticated sessions. |
+| **Static Assets** (unauthenticated) | `cross-origin` | Public assets (images, JS, CSS, fonts) can be legitimately embedded elsewhere. These are intentionally public resources. |
+| **Dynamic Content** (unauthenticated) | `same-site` | Public pages get moderate protection. Allows same-site embedding but blocks cross-origin access. |
+
+### Static Asset Detection
+The following file types are classified as static assets:
+- **Scripts & Styles**: .js, .css, .map
+- **Images**: .jpg, .jpeg, .png, .gif, .svg, .ico, .webp, .bmp
+- **Fonts**: .woff, .woff2, .ttf, .eot, .otf
+- **Data Files**: .json, .xml, .txt
+- **Media**: .mp4, .webm, .ogg, .mp3, .wav
+- **Documents**: .pdf, .zip, .tar, .gz
+
+## Security Benefits
+
+1. **Protection of Authenticated Content**: Any resource accessed by an authenticated user is protected with `same-origin`, preventing cross-origin attacks.
+
+2. **Granular Control**: Different resource types get appropriate protection levels based on their sensitivity.
+
+3. **Backward Compatibility**: Public static assets remain accessible cross-origin, maintaining compatibility with existing integrations.
+
+4. **Defense in Depth**: Works alongside other security headers (CSP, COOP, etc.) to provide layered security.
+
+## Implementation Details
+
+### Location
+`tasvideos/Extensions/ApplicationBuilderExtensions.cs`
+
+### Key Methods
+- `GetCrossOriginResourcePolicy(HttpContext)`: Determines appropriate CORP value based on context
+- `IsStaticAsset(string)`: Identifies static assets by file extension
+
+### Test Coverage
+Comprehensive test suite in `tests/TASVideos.RazorPages.Tests/Extensions/ApplicationBuilderExtensionsTests.cs`:
+- Authenticated user scenarios
+- Static asset detection (various file types)
+- Dynamic content handling
+- Edge cases (empty/null paths, case sensitivity)
+
+## Migration Notes
+
+### Breaking Changes
+None expected. The change is backwards compatible for public resources.
+
+### Behavioral Changes
+- Authenticated users: Resources now protected with `same-origin` (more restrictive)
+- Static assets: Remain `cross-origin` (no change in practice)
+- Public pages: Now `same-site` instead of `cross-origin` (slight restriction)
+
+## Future Considerations
+
+1. **Content-Type Based Detection**: Could enhance static asset detection by checking response Content-Type header in addition to file extension.
+
+2. **Path-Based Rules**: Could add specific path patterns for special cases (e.g., API endpoints, webhooks).
+
+3. **Configuration**: Could make static asset extensions configurable if needed.
+
+## References
+- [MDN: Cross-Origin-Resource-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy)
+- [OWASP Secure Headers Project](https://owasp.org/www-project-secure-headers/)

--- a/tests/TASVideos.RazorPages.Tests/Extensions/ApplicationBuilderExtensionsTests.cs
+++ b/tests/TASVideos.RazorPages.Tests/Extensions/ApplicationBuilderExtensionsTests.cs
@@ -1,0 +1,200 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using TASVideos.Extensions;
+
+namespace TASVideos.RazorPages.Tests.Extensions;
+
+[TestClass]
+public class ApplicationBuilderExtensionsTests
+{
+	[TestMethod]
+	public void GetCrossOriginResourcePolicy_AuthenticatedUser_ReturnsSameOrigin()
+	{
+		// Arrange
+		var context = CreateHttpContext(isAuthenticated: true, path: "/some/page");
+
+		// Act
+		var result = InvokeGetCrossOriginResourcePolicy(context);
+
+		// Assert
+		Assert.AreEqual("same-origin", result);
+	}
+
+	[TestMethod]
+	public void GetCrossOriginResourcePolicy_AuthenticatedUserWithStaticAsset_ReturnsSameOrigin()
+	{
+		// Arrange - Even for static assets, authenticated users get same-origin
+		var context = CreateHttpContext(isAuthenticated: true, path: "/images/test.png");
+
+		// Act
+		var result = InvokeGetCrossOriginResourcePolicy(context);
+
+		// Assert
+		Assert.AreEqual("same-origin", result);
+	}
+
+	[TestMethod]
+	[DataRow("/js/site.js")]
+	[DataRow("/css/style.css")]
+	[DataRow("/images/logo.png")]
+	[DataRow("/images/award.jpg")]
+	[DataRow("/images/icon.svg")]
+	[DataRow("/fonts/custom.woff2")]
+	[DataRow("/media/video.mp4")]
+	[DataRow("/awards/2024/winner.png")]
+	public void GetCrossOriginResourcePolicy_UnauthenticatedUserWithStaticAsset_ReturnsCrossOrigin(string path)
+	{
+		// Arrange
+		var context = CreateHttpContext(isAuthenticated: false, path: path);
+
+		// Act
+		var result = InvokeGetCrossOriginResourcePolicy(context);
+
+		// Assert
+		Assert.AreEqual("cross-origin", result);
+	}
+
+	[TestMethod]
+	[DataRow("/Publications/1234")]
+	[DataRow("/Submissions/View")]
+	[DataRow("/Profile/Settings")]
+	[DataRow("/api/endpoint")]
+	[DataRow("/")]
+	public void GetCrossOriginResourcePolicy_UnauthenticatedUserWithDynamicContent_ReturnsSameSite(string path)
+	{
+		// Arrange
+		var context = CreateHttpContext(isAuthenticated: false, path: path);
+
+		// Act
+		var result = InvokeGetCrossOriginResourcePolicy(context);
+
+		// Assert
+		Assert.AreEqual("same-site", result);
+	}
+
+	[TestMethod]
+	[DataRow("/script.JS")]
+	[DataRow("/STYLE.CSS")]
+	[DataRow("/Image.PNG")]
+	public void IsStaticAsset_CaseInsensitive_ReturnsTrue(string path)
+	{
+		// Arrange
+		var context = CreateHttpContext(isAuthenticated: false, path: path);
+
+		// Act
+		var result = InvokeIsStaticAsset(path);
+
+		// Assert
+		Assert.IsTrue(result);
+	}
+
+	[TestMethod]
+	[DataRow(".js")]
+	[DataRow(".css")]
+	[DataRow(".png")]
+	[DataRow(".jpg")]
+	[DataRow(".jpeg")]
+	[DataRow(".gif")]
+	[DataRow(".svg")]
+	[DataRow(".ico")]
+	[DataRow(".webp")]
+	[DataRow(".woff")]
+	[DataRow(".woff2")]
+	[DataRow(".ttf")]
+	[DataRow(".eot")]
+	[DataRow(".otf")]
+	[DataRow(".json")]
+	[DataRow(".xml")]
+	[DataRow(".txt")]
+	[DataRow(".mp4")]
+	[DataRow(".webm")]
+	[DataRow(".pdf")]
+	[DataRow(".zip")]
+	public void IsStaticAsset_SupportedExtensions_ReturnsTrue(string extension)
+	{
+		// Arrange
+		var path = $"/path/to/file{extension}";
+
+		// Act
+		var result = InvokeIsStaticAsset(path);
+
+		// Assert
+		Assert.IsTrue(result, $"Extension {extension} should be recognized as static asset");
+	}
+
+	[TestMethod]
+	[DataRow("/page.html")]
+	[DataRow("/page.cshtml")]
+	[DataRow("/page.aspx")]
+	[DataRow("/api/endpoint")]
+	public void IsStaticAsset_DynamicExtensions_ReturnsFalse(string path)
+	{
+		// Arrange & Act
+		var result = InvokeIsStaticAsset(path);
+
+		// Assert
+		Assert.IsFalse(result, $"Path {path} should not be recognized as static asset");
+	}
+
+	[TestMethod]
+	public void GetCrossOriginResourcePolicy_EmptyPath_ReturnsSameSite()
+	{
+		// Arrange
+		var context = CreateHttpContext(isAuthenticated: false, path: "");
+
+		// Act
+		var result = InvokeGetCrossOriginResourcePolicy(context);
+
+		// Assert
+		Assert.AreEqual("same-site", result);
+	}
+
+	[TestMethod]
+	public void GetCrossOriginResourcePolicy_NullPath_ReturnsSameSite()
+	{
+		// Arrange
+		var context = CreateHttpContext(isAuthenticated: false, path: null);
+
+		// Act
+		var result = InvokeGetCrossOriginResourcePolicy(context);
+
+		// Assert
+		Assert.AreEqual("same-site", result);
+	}
+
+	private static HttpContext CreateHttpContext(bool isAuthenticated, string? path)
+	{
+		var context = new DefaultHttpContext();
+		context.Request.Path = path ?? string.Empty;
+
+		if (isAuthenticated)
+		{
+			var identity = new ClaimsIdentity("TestAuth");
+			identity.AddClaim(new Claim(ClaimTypes.Name, "TestUser"));
+			context.User = new ClaimsPrincipal(identity);
+		}
+		else
+		{
+			context.User = new ClaimsPrincipal();
+		}
+
+		return context;
+	}
+
+	// Use reflection to invoke the private static methods
+	private static string InvokeGetCrossOriginResourcePolicy(HttpContext context)
+	{
+		var method = typeof(ApplicationBuilderExtensions)
+			.GetMethod("GetCrossOriginResourcePolicy", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+		return (string)method!.Invoke(null, [context])!;
+	}
+
+	private static bool InvokeIsStaticAsset(string path)
+	{
+		var method = typeof(ApplicationBuilderExtensions)
+			.GetMethod("IsStaticAsset", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+		return (bool)method!.Invoke(null, [path])!;
+	}
+}


### PR DESCRIPTION
…cies

Previously, all responses used 'cross-origin' CORP, which was insecure for authenticated content. This commit implements conditional CORP based on authentication status and content type:

- Authenticated users: 'same-origin' for maximum protection
- Static assets (images, js, css, fonts): 'cross-origin' for public sharing
- Public dynamic content: 'same-site' for moderate protection

Changes:
- Added GetCrossOriginResourcePolicy() to determine appropriate CORP value
- Added IsStaticAsset() to identify public static resources
- Moved CORP header setting after middleware execution for context access
- Removed TODO comment and insecure hardcoded 'cross-origin' value

Security improvements:
- Prevents cross-origin access to authenticated sessions
- Protects sensitive user data from cross-origin leaks
- Maintains backward compatibility for public resources
- Implements defense-in-depth security approach

Testing:
- Added comprehensive test suite with 15+ test cases
- Covers authenticated/unauthenticated scenarios
- Tests static asset detection for various file types
- Validates edge cases (null/empty paths, case sensitivity)

Documentation:
- Created CORP_SECURITY_IMPROVEMENTS.md with detailed analysis
- Documented policy matrix and security benefits
- Included migration notes and future considerations

Resolves security issue in ApplicationBuilderExtensions.cs:93