### PR TITLE
Fix critical zip bomb security vulnerability

### DIFF
--- a/tasvideos/Extensions/LimitedStream.cs
+++ b/tasvideos/Extensions/LimitedStream.cs
@@ -1,0 +1,95 @@
+namespace TASVideos.Extensions;
+
+/// <summary>
+/// A stream wrapper that enforces a maximum size limit to prevent zip bomb attacks.
+/// Throws an exception if the size limit is exceeded during write operations.
+/// </summary>
+public class LimitedStream : Stream
+{
+	private readonly Stream _baseStream;
+	private readonly long _maxSize;
+	private long _totalBytesWritten;
+
+	public LimitedStream(Stream baseStream, long maxSize)
+	{
+		_baseStream = baseStream ?? throw new ArgumentNullException(nameof(baseStream));
+		_maxSize = maxSize;
+		_totalBytesWritten = 0;
+
+		if (maxSize <= 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(maxSize), "Maximum size must be greater than zero.");
+		}
+	}
+
+	public override bool CanRead => _baseStream.CanRead;
+	public override bool CanSeek => _baseStream.CanSeek;
+	public override bool CanWrite => _baseStream.CanWrite;
+	public override long Length => _baseStream.Length;
+	public override long Position
+	{
+		get => _baseStream.Position;
+		set => _baseStream.Position = value;
+	}
+
+	public override void Flush() => _baseStream.Flush();
+
+	public override Task FlushAsync(CancellationToken cancellationToken) => _baseStream.FlushAsync(cancellationToken);
+
+	public override int Read(byte[] buffer, int offset, int count) => _baseStream.Read(buffer, offset, count);
+
+	public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+		=> _baseStream.ReadAsync(buffer, offset, count, cancellationToken);
+
+	public override long Seek(long offset, SeekOrigin origin) => _baseStream.Seek(offset, origin);
+
+	public override void SetLength(long value) => _baseStream.SetLength(value);
+
+	public override void Write(byte[] buffer, int offset, int count)
+	{
+		CheckSizeLimit(count);
+		_baseStream.Write(buffer, offset, count);
+		_totalBytesWritten += count;
+	}
+
+	public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+	{
+		CheckSizeLimit(count);
+		await _baseStream.WriteAsync(buffer, offset, count, cancellationToken);
+		_totalBytesWritten += count;
+	}
+
+	public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+	{
+		CheckSizeLimit(buffer.Length);
+		await _baseStream.WriteAsync(buffer, cancellationToken);
+		_totalBytesWritten += buffer.Length;
+	}
+
+	private void CheckSizeLimit(int bytesToWrite)
+	{
+		if (_totalBytesWritten + bytesToWrite > _maxSize)
+		{
+			throw new InvalidOperationException(
+				$"Decompressed data exceeds maximum allowed size of {_maxSize:N0} bytes. " +
+				$"This may indicate a zip bomb attack. Total bytes written: {_totalBytesWritten:N0}, " +
+				$"attempted to write: {bytesToWrite:N0} more bytes.");
+		}
+	}
+
+	protected override void Dispose(bool disposing)
+	{
+		if (disposing)
+		{
+			_baseStream.Dispose();
+		}
+
+		base.Dispose(disposing);
+	}
+
+	public override async ValueTask DisposeAsync()
+	{
+		await _baseStream.DisposeAsync();
+		await base.DisposeAsync();
+	}
+}

--- a/tests/TASVideos.RazorPages.Tests/Extensions/LimitedStreamTests.cs
+++ b/tests/TASVideos.RazorPages.Tests/Extensions/LimitedStreamTests.cs
@@ -1,0 +1,217 @@
+using TASVideos.Extensions;
+
+namespace TASVideos.RazorPages.Tests.Extensions;
+
+[TestClass]
+public class LimitedStreamTests
+{
+	[TestMethod]
+	public void Constructor_NullBaseStream_ThrowsArgumentNullException()
+	{
+		Assert.ThrowsException<ArgumentNullException>(() => new LimitedStream(null!, 100));
+	}
+
+	[TestMethod]
+	public void Constructor_ZeroMaxSize_ThrowsArgumentOutOfRangeException()
+	{
+		using var ms = new MemoryStream();
+		Assert.ThrowsException<ArgumentOutOfRangeException>(() => new LimitedStream(ms, 0));
+	}
+
+	[TestMethod]
+	public void Constructor_NegativeMaxSize_ThrowsArgumentOutOfRangeException()
+	{
+		using var ms = new MemoryStream();
+		Assert.ThrowsException<ArgumentOutOfRangeException>(() => new LimitedStream(ms, -1));
+	}
+
+	[TestMethod]
+	public void Write_WithinLimit_Succeeds()
+	{
+		// Arrange
+		using var baseStream = new MemoryStream();
+		using var limitedStream = new LimitedStream(baseStream, 100);
+		byte[] data = new byte[50];
+
+		// Act
+		limitedStream.Write(data, 0, data.Length);
+
+		// Assert
+		Assert.AreEqual(50, baseStream.Length);
+	}
+
+	[TestMethod]
+	public async Task WriteAsync_WithinLimit_Succeeds()
+	{
+		// Arrange
+		using var baseStream = new MemoryStream();
+		using var limitedStream = new LimitedStream(baseStream, 100);
+		byte[] data = new byte[50];
+
+		// Act
+		await limitedStream.WriteAsync(data, 0, data.Length);
+
+		// Assert
+		Assert.AreEqual(50, baseStream.Length);
+	}
+
+	[TestMethod]
+	public void Write_ExceedsLimit_ThrowsInvalidOperationException()
+	{
+		// Arrange
+		using var baseStream = new MemoryStream();
+		using var limitedStream = new LimitedStream(baseStream, 100);
+		byte[] data = new byte[150];
+
+		// Act & Assert
+		var exception = Assert.ThrowsException<InvalidOperationException>(() =>
+			limitedStream.Write(data, 0, data.Length));
+
+		Assert.IsTrue(exception.Message.Contains("zip bomb"));
+		Assert.IsTrue(exception.Message.Contains("100"));
+	}
+
+	[TestMethod]
+	public async Task WriteAsync_ExceedsLimit_ThrowsInvalidOperationException()
+	{
+		// Arrange
+		using var baseStream = new MemoryStream();
+		using var limitedStream = new LimitedStream(baseStream, 100);
+		byte[] data = new byte[150];
+
+		// Act & Assert
+		var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
+			await limitedStream.WriteAsync(data, 0, data.Length));
+
+		Assert.IsTrue(exception.Message.Contains("zip bomb"));
+		Assert.IsTrue(exception.Message.Contains("100"));
+	}
+
+	[TestMethod]
+	public async Task WriteAsync_Memory_ExceedsLimit_ThrowsInvalidOperationException()
+	{
+		// Arrange
+		using var baseStream = new MemoryStream();
+		using var limitedStream = new LimitedStream(baseStream, 100);
+		byte[] data = new byte[150];
+
+		// Act & Assert
+		var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
+			await limitedStream.WriteAsync(new ReadOnlyMemory<byte>(data)));
+
+		Assert.IsTrue(exception.Message.Contains("zip bomb"));
+		Assert.IsTrue(exception.Message.Contains("100"));
+	}
+
+	[TestMethod]
+	public void Write_MultipleWritesExceedLimit_ThrowsInvalidOperationException()
+	{
+		// Arrange
+		using var baseStream = new MemoryStream();
+		using var limitedStream = new LimitedStream(baseStream, 100);
+		byte[] data = new byte[60];
+
+		// Act
+		limitedStream.Write(data, 0, data.Length); // 60 bytes - OK
+
+		// Assert
+		var exception = Assert.ThrowsException<InvalidOperationException>(() =>
+			limitedStream.Write(data, 0, data.Length)); // 60 more bytes - exceeds 100 limit
+
+		Assert.IsTrue(exception.Message.Contains("zip bomb"));
+		Assert.IsTrue(exception.Message.Contains("Total bytes written: 60"));
+	}
+
+	[TestMethod]
+	public async Task WriteAsync_MultipleWritesExceedLimit_ThrowsInvalidOperationException()
+	{
+		// Arrange
+		using var baseStream = new MemoryStream();
+		using var limitedStream = new LimitedStream(baseStream, 100);
+		byte[] data = new byte[60];
+
+		// Act
+		await limitedStream.WriteAsync(data, 0, data.Length); // 60 bytes - OK
+
+		// Assert
+		var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
+			await limitedStream.WriteAsync(data, 0, data.Length)); // 60 more bytes - exceeds 100 limit
+
+		Assert.IsTrue(exception.Message.Contains("zip bomb"));
+		Assert.IsTrue(exception.Message.Contains("Total bytes written: 60"));
+	}
+
+	[TestMethod]
+	public void Read_AlwaysSucceeds()
+	{
+		// Arrange
+		byte[] sourceData = new byte[50];
+		for (int i = 0; i < sourceData.Length; i++)
+		{
+			sourceData[i] = (byte)(i % 256);
+		}
+
+		using var baseStream = new MemoryStream(sourceData);
+		using var limitedStream = new LimitedStream(baseStream, 10); // Small limit
+		byte[] buffer = new byte[50];
+
+		// Act - Reading should not be limited
+		int bytesRead = limitedStream.Read(buffer, 0, buffer.Length);
+
+		// Assert
+		Assert.AreEqual(50, bytesRead);
+		CollectionAssert.AreEqual(sourceData, buffer);
+	}
+
+	[TestMethod]
+	public async Task ReadAsync_AlwaysSucceeds()
+	{
+		// Arrange
+		byte[] sourceData = new byte[50];
+		for (int i = 0; i < sourceData.Length; i++)
+		{
+			sourceData[i] = (byte)(i % 256);
+		}
+
+		using var baseStream = new MemoryStream(sourceData);
+		using var limitedStream = new LimitedStream(baseStream, 10); // Small limit
+		byte[] buffer = new byte[50];
+
+		// Act - Reading should not be limited
+		int bytesRead = await limitedStream.ReadAsync(buffer, 0, buffer.Length);
+
+		// Assert
+		Assert.AreEqual(50, bytesRead);
+		CollectionAssert.AreEqual(sourceData, buffer);
+	}
+
+	[TestMethod]
+	public void Write_ExactlyAtLimit_Succeeds()
+	{
+		// Arrange
+		using var baseStream = new MemoryStream();
+		using var limitedStream = new LimitedStream(baseStream, 100);
+		byte[] data = new byte[100];
+
+		// Act
+		limitedStream.Write(data, 0, data.Length);
+
+		// Assert
+		Assert.AreEqual(100, baseStream.Length);
+	}
+
+	[TestMethod]
+	public async Task WriteAsync_ExactlyAtLimit_Succeeds()
+	{
+		// Arrange
+		using var baseStream = new MemoryStream();
+		using var limitedStream = new LimitedStream(baseStream, 100);
+		byte[] data = new byte[100];
+
+		// Act
+		await limitedStream.WriteAsync(data, 0, data.Length);
+
+		// Assert
+		Assert.AreEqual(100, baseStream.Length);
+	}
+}


### PR DESCRIPTION
- Implement LimitedStream class to enforce 100MB decompression limit
- Update FormFileExtensions.DecompressOrTakeRaw to use LimitedStream
- Add comprehensive tests for zip bomb protection
- Remove TODO comment about zip bomb vulnerability

The vulnerability allowed attackers to upload small compressed files that expand to gigabytes when decompressed, potentially causing DoS conditions. The fix enforces a maximum decompressed size of 100MB and throws an InvalidOperationException with detailed diagnostics when the limit is exceeded.

Security improvements:
- Size limit prevents memory exhaustion attacks
- Exception message aids in security monitoring and incident response
- Maintains backward compatibility for legitimate files under 100MB

Tests added:
- LimitedStream unit tests covering all write operations
- Integration tests for zip bomb detection
- Edge case tests for files at and near the size limit