### PR TITLE
Add CodeQL security scanning to CI/CD pipeline

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,66 @@
+name: "CodeQL Security Scan"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    # Run daily at 2:00 AM UTC
+    - cron: '0 2 * * *'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'csharp' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up .NET Core 8.0.x
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        # Use the security-and-quality query suite for comprehensive analysis
+        queries: security-and-quality
+        # Exclude test files from certain checks to reduce noise
+        config: |
+          paths-ignore:
+            - '**/Tests/**'
+            - '**/test/**'
+            - '**/*.Test/**'
+            - '**/*.Tests/**'
+
+    # Restore dependencies before building
+    - name: Restore dependencies
+      run: dotnet restore
+
+    # Build the project
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+
+    # Perform CodeQL Analysis
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"
+        # Upload SARIF file to GitHub Security tab
+        upload: true
+        # Don't fail the workflow on findings - report only
+        fail-on: never

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![.NET Core](https://github.com/TASVideos/tasvideos/workflows/.NET%20Core/badge.svg)
+[![CodeQL](https://github.com/TASVideos/tasvideos/workflows/CodeQL%20Security%20Scan/badge.svg)](https://github.com/TASVideos/tasvideos/security/code-scanning)
 
 [![GitHub open issues counter](https://img.shields.io/github/issues-raw/TASVideos/tasvideos.svg?logo=github&logoColor=333333&style=popout)](https://github.com/TASVideos/tasvideos/issues)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/7161/badge)](https://www.bestpractices.dev/projects/7161)


### PR DESCRIPTION
- Create CodeQL workflow with daily scans and PR triggers
- Configure for C# with security-and-quality query suite
- Exclude test files from analysis to reduce noise
- Upload SARIF results to GitHub Security tab
- Set to report-only mode (won't block PRs)
- Add CodeQL badge to README

Benefits:
- Automated security vulnerability detection
- CWE/CVE tracking aligned with industry best practices
- Free for public repositories